### PR TITLE
make statistic class persistable on multiple instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "jsdoc-export-default-interop": "^0.3.1",
         "portastic": "^1.0.1",
         "prettier": "^2.0.5",
-        "proxy": "^1.0.1",
+        "proxy": "^1.0.2",
         "sinon": "^9.0.2",
         "sinon-stub-promise": "^4.0.0",
         "socket.io-client": "^2.3.0",

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -302,7 +302,8 @@ class BasicCrawler {
         await this._loadHandledRequestCount();
 
         this.isRunningPromise = this.autoscaledPool.run();
-        this.stats.startLogging();
+        await this.stats.startLogging();
+
         try {
             await this.isRunningPromise;
         } finally {
@@ -310,7 +311,7 @@ class BasicCrawler {
                 await this.sessionPool.teardown();
             }
 
-            this.stats.stopLogging();
+            await this.stats.stopLogging();
             const finalStats = this.stats.getCurrent();
             this.log.info('Final request statistics:', finalStats);
         }

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -302,7 +302,7 @@ class BasicCrawler {
         await this._loadHandledRequestCount();
 
         this.isRunningPromise = this.autoscaledPool.run();
-        await this.stats.startLogging();
+        await this.stats.startCapturing();
 
         try {
             await this.isRunningPromise;
@@ -311,13 +311,14 @@ class BasicCrawler {
                 await this.sessionPool.teardown();
             }
 
-            await this.stats.stopLogging();
+            await this.stats.stopCapturing();
             const finalStats = this.stats.getCurrent();
             this.log.info('Final request statistics:', finalStats);
         }
     }
 
     async _pauseOnMigration() {
+        await this.stats.persistState();
         await this.autoscaledPool.pause(SAFE_MIGRATION_WAIT_MILLIS)
             .catch((err) => {
                 if (err.message.includes('running tasks did not finish')) {

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -23,7 +23,7 @@ import AutoscaledPool, { AutoscaledPoolOptions } from '../autoscaling/autoscaled
 import { HandleFailedRequest } from './basic_crawler';
 import Request from '../request';
 import { RequestList } from '../request_list';
-import { ProxyConfiguration } from '../proxy_configuration';
+import { ProxyConfiguration, ProxyInfo } from '../proxy_configuration';
 import { RequestQueue } from '../request_queue';
 import { Session } from '../session_pool/session';
 import { SessionPoolOptions } from '../session_pool/session_pool';

--- a/src/crawlers/puppeteer_crawler.js
+++ b/src/crawlers/puppeteer_crawler.js
@@ -21,7 +21,7 @@ import AutoscaledPool, { AutoscaledPoolOptions } from '../autoscaling/autoscaled
 import { LaunchPuppeteerOptions } from '../puppeteer'; // eslint-disable-line no-unused-vars,import/named
 import { Session } from '../session_pool/session'; // eslint-disable-line no-unused-vars
 import { SessionPoolOptions } from '../session_pool/session_pool';
-import { ProxyConfiguration } from '../proxy_configuration';
+import { ProxyConfiguration, ProxyInfo } from '../proxy_configuration';
 // eslint-enable-line import/no-duplicates
 
 /**

--- a/src/crawlers/statistics.js
+++ b/src/crawlers/statistics.js
@@ -215,7 +215,9 @@ class Statistics {
         this.finishedJobs = savedState.finishedJobs;
         this.failedJobs = savedState.failedJobs;
         this.totalJobDurationMillis = savedState.totalJobDurationMillis;
-        this.startedAt = new Date(Date.now() - (savedState.persistedAt - savedState.startedAt));
+        // persisted state uses ISO date strings
+        const [persistedAt, startedAt] = ['persistedAt', 'startedAt'].map(key => new Date(savedState[key]).getTime());
+        this.startedAt = new Date(Date.now() - (persistedAt - startedAt));
 
         this.log.debug('Loaded from KeyValueStore');
     }
@@ -245,9 +247,9 @@ class Statistics {
             finishedJobs: this.finishedJobs,
             failedJobs: this.failedJobs,
             totalJobDurationMillis: this.totalJobDurationMillis,
-            startedAt: +this.startedAt,
+            startedAt: this.startedAt ? this.startedAt.toISOString() : null,
             // used for adjusting time between runs recreating from state
-            persistedAt: Date.now(),
+            persistedAt: new Date().toISOString(),
         };
     }
 }

--- a/src/request_list.js
+++ b/src/request_list.js
@@ -260,8 +260,9 @@ export class RequestList {
         // Note that reclaimedRequests is always a subset of inProgress!
         this.reclaimed = {};
 
-        this.persistStateKey = persistStateKey;
+        this.persistStateKey = persistStateKey ? `SDK_${persistStateKey}` : persistStateKey;
         this.persistRequestsKey = persistRequestsKey || persistSourcesKey;
+        this.persistRequestsKey = this.persistRequestsKey ? `SDK_${persistRequestsKey}` : this.persistRequestsKey;
 
         this.initialState = state;
 

--- a/src/session_pool/session_pool.js
+++ b/src/session_pool/session_pool.js
@@ -94,7 +94,7 @@ export class SessionPool extends EventEmitter {
             maxPoolSize = 1000,
 
             persistStateKeyValueStoreId = null,
-            persistStateKey = 'SESSION_POOL_STATE',
+            persistStateKey = 'SDK_SESSION_POOL_STATE',
 
             createSessionFunction = null,
             sessionOptions = {},

--- a/test/crawlers/basic_crawler.test.js
+++ b/test/crawlers/basic_crawler.test.js
@@ -89,6 +89,9 @@ describe('BasicCrawler', () => {
             // The crawler will pause after 200 requests
             const runPromise = basicCrawler.run();
             runPromise.then(() => { finished = true; });
+
+            // need to monkeypatch the stats class, otherwise it will never finish
+            basicCrawler.stats.persistState = () => Promise.resolve();
             await persistPromise;
 
             expect(finished).toBe(false);

--- a/test/crawlers/statistics.test.js
+++ b/test/crawlers/statistics.test.js
@@ -41,7 +41,7 @@ describe('Statistics', () => {
         test('should increment id by each new consecutive instance', () => {
             expect(stats.id).toEqual(0);
             expect(Statistics.id).toEqual(1);
-            expect(stats.persistStateKey).toEqual('STATISTICS_STATE_0');
+            expect(stats.persistStateKey).toEqual('SDK_CRAWLER_STATISTICS_0');
             const [n1, n2] = [new Statistics(), new Statistics()];
             expect(n1.id).toEqual(1);
             expect(n2.id).toEqual(2);
@@ -61,30 +61,50 @@ describe('Statistics', () => {
             const state = await stats.keyValueStore.getValue(stats.persistStateKey);
 
             expect(state).toEqual({
-                jobRetryHistogram: [1],
-                finishedJobs: 1,
-                failedJobs: 0,
-                avgDurationMillis: 100,
-                perMinute: 600,
-                persistedAt: toISOString(startedAt + 100),
-                totalJobDurationMillis: 100,
-                runtimeMillis: 1000,
-                startedAt: toISOString(startedAt),
+                crawlerFinishedAt: null,
+                crawlerRuntimeMillis: 1100,
+                crawlerStartedAt: toISOString(startedAt + 100),
+                requestAvgFailedDurationMillis: null,
+                requestAvgFinishedDurationMillis: 100,
+                requestMaxDurationMillis: 100,
+                requestMinDurationMillis: 100,
+                requestTotalDurationMillis: 100,
+                requestRetryHistogram: [1],
+                requestTotalFailedDurationMillis: 0,
+                requestTotalFinishedDurationMillis: 100,
+                requestsFailed: 0,
+                requestsFailedPerMinute: 0,
+                requestsFinished: 1,
+                requestsFinishedPerMinute: 55,
+                requestsRetries: 0,
+                requestsTotal: 1,
+                statsId: stats.id,
+                statsPersistedAt: toISOString(startedAt + 100),
             });
 
             await stats.stopCapturing();
             stats.reset();
 
             expect(stats.toJSON()).toEqual({
-                avgDurationMillis: Infinity,
-                perMinute: 0,
-                jobRetryHistogram: [],
-                finishedJobs: 0,
-                failedJobs: 0,
-                runtimeMillis: null,
-                persistedAt: toISOString(startedAt + 100),
-                totalJobDurationMillis: 0,
-                startedAt: null,
+                crawlerFinishedAt: null,
+                crawlerRuntimeMillis: 0,
+                crawlerStartedAt: null,
+                requestAvgFailedDurationMillis: Infinity,
+                requestAvgFinishedDurationMillis: Infinity,
+                requestMaxDurationMillis: 0,
+                requestMinDurationMillis: Infinity,
+                requestRetryHistogram: [],
+                requestTotalDurationMillis: 0,
+                requestTotalFailedDurationMillis: 0,
+                requestTotalFinishedDurationMillis: 0,
+                requestsFailed: 0,
+                requestsFailedPerMinute: 0,
+                requestsFinished: 0,
+                requestsFinishedPerMinute: 0,
+                requestsRetries: 0,
+                requestsTotal: 0,
+                statsId: stats.id,
+                statsPersistedAt: toISOString(startedAt + 100),
             });
 
             await stats.startCapturing();
@@ -96,25 +116,37 @@ describe('Statistics', () => {
             clock.tick(1000);
 
             expect(stats.toJSON()).toEqual({
-                avgDurationMillis: 100,
-                jobRetryHistogram: [2],
-                finishedJobs: 2,
-                failedJobs: 0,
-                runtimeMillis: 1000,
-                perMinute: 100,
-                persistedAt: toISOString(startedAt + 1200),
-                totalJobDurationMillis: 200,
-                startedAt: toISOString(startedAt),
+                crawlerRuntimeMillis: 2200,
+                crawlerFinishedAt: toISOString(startedAt + 100),
+                crawlerStartedAt: toISOString(startedAt + 100),
+                requestAvgFailedDurationMillis: Infinity,
+                requestAvgFinishedDurationMillis: 100,
+                requestMaxDurationMillis: 100,
+                requestMinDurationMillis: 100,
+                requestRetryHistogram: [2],
+                requestTotalDurationMillis: 200,
+                requestTotalFailedDurationMillis: 0,
+                requestTotalFinishedDurationMillis: 200,
+                requestsFailed: 0,
+                requestsFailedPerMinute: 0,
+                requestsFinished: 2,
+                requestsFinishedPerMinute: 55,
+                requestsRetries: 0,
+                requestsTotal: 2,
+                statsId: stats.id,
+                statsPersistedAt: toISOString(startedAt + 1200),
             });
 
             clock.tick(10000);
 
-            expect(stats.getCurrent()).toEqual({
-                avgDurationMillis: 100,
-                perMinute: getPerMinute(2, 11200),
-                finished: 2,
-                failed: 0,
-                retryHistogram: [2],
+            expect(stats.calculate()).toEqual({
+                crawlerRuntimeMillis: 12200,
+                requestAvgFailedDurationMillis: Infinity,
+                requestAvgFinishedDurationMillis: 100,
+                requestTotalDurationMillis: 200,
+                requestsFailedPerMinute: 0,
+                requestsFinishedPerMinute: getPerMinute(2, 12200),
+                requestsTotal: 2,
             });
         });
 
@@ -143,7 +175,7 @@ describe('Statistics', () => {
 
             events.emit(ACTOR_EVENT_NAMES_EX.PERSIST_STATE);
 
-            const { retryHistogram, finished, failed, ...rest } = stats.getCurrent();
+            const { retryHistogram, finished, failed, ...rest } = stats.calculate();
 
             expect(spy.getCall(0).args).toEqual([stats.persistStateKey, { ...state, ...rest }]);
         }, 2000);
@@ -154,13 +186,15 @@ describe('Statistics', () => {
         clock.tick(1);
         stats.finishJob(0);
         clock.tick(1);
-        const current = stats.getCurrent();
+        const current = stats.calculate();
         expect(current).toEqual({
-            avgDurationMillis: 1,
-            perMinute: getPerMinute(1, 2),
-            finished: 1,
-            failed: 0,
-            retryHistogram: [1],
+            crawlerRuntimeMillis: 2,
+            requestAvgFailedDurationMillis: Infinity,
+            requestAvgFinishedDurationMillis: 1,
+            requestTotalDurationMillis: 1,
+            requestsFailedPerMinute: 0,
+            requestsFinishedPerMinute: getPerMinute(1, 2),
+            requestsTotal: 1,
         });
     });
 
@@ -169,14 +203,17 @@ describe('Statistics', () => {
         clock.tick(0);
         stats.failJob(0);
         clock.tick(1);
-        const current = stats.getCurrent();
+        const current = stats.calculate();
         expect(current).toEqual({
-            avgDurationMillis: Infinity,
-            perMinute: 0,
-            finished: 0,
-            failed: 1,
-            retryHistogram: [1],
+            crawlerRuntimeMillis: 1,
+            requestAvgFailedDurationMillis: Infinity,
+            requestAvgFinishedDurationMillis: Infinity,
+            requestTotalDurationMillis: 0,
+            requestsFailedPerMinute: 60000,
+            requestsFinishedPerMinute: 0,
+            requestsTotal: 1,
         });
+        expect(stats.requestRetryHistogram).toEqual([1]);
     });
 
     test('should collect retries', () => {
@@ -189,14 +226,17 @@ describe('Statistics', () => {
         stats.finishJob(1);
         stats.startJob(2);
         stats.finishJob(2);
-        const current = stats.getCurrent();
+        const current = stats.calculate();
         expect(current).toEqual({
-            avgDurationMillis: Infinity,
-            perMinute: Infinity,
-            finished: 3,
-            failed: 0,
-            retryHistogram: [1, 1, 1],
+            crawlerRuntimeMillis: 0,
+            requestAvgFailedDurationMillis: Infinity,
+            requestAvgFinishedDurationMillis: Infinity,
+            requestTotalDurationMillis: 0,
+            requestsFailedPerMinute: 0,
+            requestsFinishedPerMinute: Infinity,
+            requestsTotal: 3,
         });
+        expect(stats.requestRetryHistogram).toEqual([1, 1, 1]);
     });
 
     test('should return correct stats for multiple parallel jobs', () => {
@@ -213,14 +253,21 @@ describe('Statistics', () => {
         stats.finishJob(2); // runtime: 13ms
         clock.tick(10); // since startedAt: 25ms
 
-        const current = stats.getCurrent();
+        const current = stats.calculate();
         expect(current).toEqual({
-            avgDurationMillis: (13 + 3) / 2,
-            perMinute: getPerMinute(2, 25),
-            finished: 2,
-            failed: 1,
-            retryHistogram: [3],
+            crawlerRuntimeMillis: 25,
+            requestAvgFailedDurationMillis: 5,
+            requestAvgFinishedDurationMillis: (13 + 3) / 2,
+            requestTotalDurationMillis: 21,
+            requestsFailedPerMinute: 2400,
+            requestsFinishedPerMinute: getPerMinute(2, 25),
+            requestsTotal: 3,
         });
+        expect(stats.state).toMatchObject({
+            requestsFailed: 1,
+            requestsFinished: 2,
+        });
+        expect(stats.requestRetryHistogram).toEqual([3]);
     });
 
     test('should regularly log stats', async () => {
@@ -239,10 +286,13 @@ describe('Statistics', () => {
         expect(logged).toHaveLength(1);
         expect(logged[0][0]).toBe('Statistics');
         expect(logged[0][1]).toEqual({
-            avgDurationMillis: 1,
-            perMinute: 1,
-            finished: 1,
-            failed: 0,
+            crawlerRuntimeMillis: 60001,
+            requestAvgFailedDurationMillis: Infinity,
+            requestAvgFinishedDurationMillis: 1,
+            requestTotalDurationMillis: 1,
+            requestsFailedPerMinute: 0,
+            requestsFinishedPerMinute: 1,
+            requestsTotal: 1,
             retryHistogram: [1],
         });
         await stats.stopCapturing();
@@ -250,10 +300,13 @@ describe('Statistics', () => {
         expect(logged).toHaveLength(1);
         expect(logged[0][0]).toBe('Statistics');
         expect(logged[0][1]).toEqual({
-            avgDurationMillis: 1,
-            perMinute: 1,
-            finished: 1,
-            failed: 0,
+            crawlerRuntimeMillis: 60001,
+            requestAvgFailedDurationMillis: Infinity,
+            requestAvgFinishedDurationMillis: 1,
+            requestTotalDurationMillis: 1,
+            requestsFailedPerMinute: 0,
+            requestsFinishedPerMinute: 1,
+            requestsTotal: 1,
             retryHistogram: [1],
         });
     });
@@ -263,12 +316,10 @@ describe('Statistics', () => {
         stats.startJob(1);
         clock.tick(3);
         stats.finishJob(1);
-        let current = stats.getCurrent();
-        expect(current.finished).toEqual(1);
-        expect(current.retryHistogram).toEqual([1]);
+        expect(stats.state.requestsFinished).toEqual(1);
+        expect(stats.requestRetryHistogram).toEqual([1]);
         stats.reset();
-        current = stats.getCurrent();
-        expect(current.finished).toEqual(0);
-        expect(current.retryHistogram).toEqual([]);
+        expect(stats.state.requestsFinished).toEqual(0);
+        expect(stats.requestRetryHistogram).toEqual([]);
     });
 });

--- a/test/crawlers/statistics.test.js
+++ b/test/crawlers/statistics.test.js
@@ -64,8 +64,11 @@ describe('Statistics', () => {
                 jobRetryHistogram: [1],
                 finishedJobs: 1,
                 failedJobs: 0,
+                avgDurationMillis: 100,
+                perMinute: 600,
                 persistedAt: toISOString(startedAt + 100),
                 totalJobDurationMillis: 100,
+                runtimeMillis: 1000,
                 startedAt: toISOString(startedAt),
             });
 
@@ -73,9 +76,12 @@ describe('Statistics', () => {
             stats.reset();
 
             expect(stats.toJSON()).toEqual({
+                avgDurationMillis: Infinity,
+                perMinute: 0,
                 jobRetryHistogram: [],
                 finishedJobs: 0,
                 failedJobs: 0,
+                runtimeMillis: null,
                 persistedAt: toISOString(startedAt + 100),
                 totalJobDurationMillis: 0,
                 startedAt: null,
@@ -90,9 +96,12 @@ describe('Statistics', () => {
             clock.tick(1000);
 
             expect(stats.toJSON()).toEqual({
+                avgDurationMillis: 100,
                 jobRetryHistogram: [2],
                 finishedJobs: 2,
                 failedJobs: 0,
+                runtimeMillis: 1000,
+                perMinute: 100,
                 persistedAt: toISOString(startedAt + 1200),
                 totalJobDurationMillis: 200,
                 startedAt: toISOString(startedAt),
@@ -134,7 +143,9 @@ describe('Statistics', () => {
 
             events.emit(ACTOR_EVENT_NAMES_EX.PERSIST_STATE);
 
-            expect(spy.getCall(0).args).toEqual([stats.persistStateKey, state]);
+            const { retryHistogram, finished, failed, ...rest } = stats.getCurrent();
+
+            expect(spy.getCall(0).args).toEqual([stats.persistStateKey, { ...state, ...rest }]);
         }, 2000);
     });
 

--- a/test/crawlers/statistics.test.js
+++ b/test/crawlers/statistics.test.js
@@ -62,6 +62,7 @@ describe('Statistics', () => {
 
             expect(state).toEqual({
                 crawlerFinishedAt: null,
+                crawlerLastStartTimestamp: 0,
                 crawlerRuntimeMillis: 1100,
                 crawlerStartedAt: toISOString(startedAt + 100),
                 requestAvgFailedDurationMillis: null,
@@ -88,6 +89,7 @@ describe('Statistics', () => {
             expect(stats.toJSON()).toEqual({
                 crawlerFinishedAt: null,
                 crawlerRuntimeMillis: 0,
+                crawlerLastStartTimestamp: 1100,
                 crawlerStartedAt: null,
                 requestAvgFailedDurationMillis: Infinity,
                 requestAvgFinishedDurationMillis: Infinity,
@@ -117,6 +119,7 @@ describe('Statistics', () => {
 
             expect(stats.toJSON()).toEqual({
                 crawlerRuntimeMillis: 2200,
+                crawlerLastStartTimestamp: 0,
                 crawlerFinishedAt: toISOString(startedAt + 100),
                 crawlerStartedAt: toISOString(startedAt + 100),
                 requestAvgFailedDurationMillis: Infinity,

--- a/test/crawlers/statistics.test.js
+++ b/test/crawlers/statistics.test.js
@@ -9,6 +9,8 @@ describe('Statistics', () => {
         return Math.round(jobCount / (totalTickMillis / 1000 / 60));
     };
 
+    const toISOString = date => new Date(date).toISOString();
+
     let clock;
     let stats;
     let localStorageEmulator;
@@ -62,9 +64,9 @@ describe('Statistics', () => {
                 jobRetryHistogram: [1],
                 finishedJobs: 1,
                 failedJobs: 0,
-                persistedAt: startedAt + 100,
+                persistedAt: toISOString(startedAt + 100),
                 totalJobDurationMillis: 100,
-                startedAt,
+                startedAt: toISOString(startedAt),
             });
 
             await stats.stopCapturing();
@@ -74,9 +76,9 @@ describe('Statistics', () => {
                 jobRetryHistogram: [],
                 finishedJobs: 0,
                 failedJobs: 0,
-                persistedAt: startedAt + 100,
+                persistedAt: toISOString(startedAt + 100),
                 totalJobDurationMillis: 0,
-                startedAt: 0,
+                startedAt: null,
             });
 
             await stats.startCapturing();
@@ -91,9 +93,9 @@ describe('Statistics', () => {
                 jobRetryHistogram: [2],
                 finishedJobs: 2,
                 failedJobs: 0,
-                persistedAt: startedAt + 1200,
+                persistedAt: toISOString(startedAt + 1200),
                 totalJobDurationMillis: 200,
-                startedAt,
+                startedAt: toISOString(startedAt),
             });
 
             clock.tick(10000);

--- a/test/request_list.test.js
+++ b/test/request_list.test.js
@@ -403,11 +403,12 @@ describe('Apify.RequestList', () => {
         'should correctly persist its state when persistStateKey is set',
         async () => {
             const PERSIST_STATE_KEY = 'some-key';
+            const SDK_KEY = `SDK_${PERSIST_STATE_KEY}`;
             const mock = sinon.mock(keyValueStore);
 
             mock.expects('getValue')
                 .once()
-                .withArgs(PERSIST_STATE_KEY)
+                .withArgs(SDK_KEY)
                 .returns(null);
 
             const opts = {
@@ -431,7 +432,7 @@ describe('Apify.RequestList', () => {
             // Persist state.
             mock.expects('setValue')
                 .once()
-                .withArgs(PERSIST_STATE_KEY, requestList.getState())
+                .withArgs(SDK_KEY, requestList.getState())
                 .returns(Promise.resolve());
             Apify.events.emit(ACTOR_EVENT_NAMES_EX.PERSIST_STATE);
             await utils.sleep(1);
@@ -444,7 +445,7 @@ describe('Apify.RequestList', () => {
             expect(requestList.isStatePersisted).toBe(false);
             mock.expects('setValue')
                 .once()
-                .withArgs(PERSIST_STATE_KEY, requestList.getState())
+                .withArgs(SDK_KEY, requestList.getState())
                 .returns(Promise.resolve());
             Apify.events.emit(ACTOR_EVENT_NAMES_EX.PERSIST_STATE);
             await utils.sleep(1);
@@ -458,7 +459,7 @@ describe('Apify.RequestList', () => {
             // of original request list.
             mock.expects('getValue')
                 .once()
-                .withArgs(PERSIST_STATE_KEY)
+                .withArgs(SDK_KEY)
                 .returns(Promise.resolve(requestList.getState()));
             const requestList2 = new Apify.RequestList(optsCopy);
             await requestList2.initialize();
@@ -472,6 +473,7 @@ describe('Apify.RequestList', () => {
         'should correctly persist its sources when persistRequestsKey is set',
         async () => {
             const PERSIST_REQUESTS_KEY = 'some-key';
+            const SDK_KEY = `SDK_${PERSIST_REQUESTS_KEY}`;
             const getValueStub = sinon.stub(keyValueStore, 'getValue');
             const setValueStub = sinon.stub(keyValueStore, 'setValue');
 
@@ -490,7 +492,7 @@ describe('Apify.RequestList', () => {
             expect(requestList.areRequestsPersisted).toBe(false);
 
             // Expect an attempt to load sources.
-            getValueStub.withArgs(PERSIST_REQUESTS_KEY)
+            getValueStub.withArgs(SDK_KEY)
                 .onFirstCall()
                 .resolves(null)
                 // See second RequestList below.
@@ -500,7 +502,7 @@ describe('Apify.RequestList', () => {
                 });
 
             // Expect persist sources.
-            setValueStub.withArgs(PERSIST_REQUESTS_KEY)
+            setValueStub.withArgs(SDK_KEY)
                 .callsFake(async (key, value) => {
                     persistedRequests = value;
                 });
@@ -535,6 +537,7 @@ describe('Apify.RequestList', () => {
         'should correctly persist sources from requestsFromUrl if persistRequestsKey is set',
         async () => {
             const PERSIST_REQUESTS_KEY = 'some-key';
+            const SDK_KEY = `SDK_${PERSIST_REQUESTS_KEY}`;
             const kvsMock = sinon.mock(keyValueStore);
             const publicUtilsMock = sinon.mock(utils.publicUtils);
 
@@ -558,13 +561,13 @@ describe('Apify.RequestList', () => {
             // Expect an attempt to load sources.
             kvsMock.expects('getValue')
                 .once()
-                .withArgs(PERSIST_REQUESTS_KEY)
+                .withArgs(SDK_KEY)
                 .resolves(null);
 
             // Expect persist sources.
             kvsMock.expects('setValue')
                 .once()
-                .withArgs(PERSIST_REQUESTS_KEY)
+                .withArgs(SDK_KEY)
                 .callsFake((key, value) => {
                     persistedRequests = value;
                 });
@@ -724,12 +727,13 @@ describe('Apify.RequestList', () => {
             mock.expects('setValue').atLeast(1).resolves();
 
             const name = 'xxx';
+            const SDK_KEY = `SDK_${name}`;
             const sources = [{ url: 'https://example.com' }];
 
             const rl = await Apify.openRequestList(name, sources);
             expect(rl).toBeInstanceOf(Apify.RequestList);
-            expect(rl.persistStateKey.startsWith(name)).toBe(true);
-            expect(rl.persistRequestsKey.startsWith(name)).toBe(true);
+            expect(rl.persistStateKey.startsWith(SDK_KEY)).toBe(true);
+            expect(rl.persistRequestsKey.startsWith(SDK_KEY)).toBe(true);
             expect(rl.sources).toEqual([]);
             expect(rl.isInitialized).toBe(true);
 
@@ -741,13 +745,14 @@ describe('Apify.RequestList', () => {
             mock.expects('setValue').atLeast(1).resolves();
 
             const name = 'xxx';
+            const SDK_KEY = `SDK_${name}`;
             const sources = ['https://example.com'];
             const requests = sources.map(url => new Apify.Request({ url }));
 
             const rl = await Apify.openRequestList(name, sources);
             expect(rl).toBeInstanceOf(Apify.RequestList);
-            expect(rl.persistStateKey.startsWith(name)).toBe(true);
-            expect(rl.persistRequestsKey.startsWith(name)).toBe(true);
+            expect(rl.persistStateKey.startsWith(SDK_KEY)).toBe(true);
+            expect(rl.persistRequestsKey.startsWith(SDK_KEY)).toBe(true);
             expect(rl.requests).toEqual(requests);
             expect(rl.isInitialized).toBe(true);
 
@@ -759,6 +764,7 @@ describe('Apify.RequestList', () => {
             mock.expects('setValue').atLeast(1).resolves();
 
             const name = 'xxx';
+            const SDK_KEY = `SDK_${name}`;
             let counter = 0;
             const sources = [{ url: 'https://example.com' }];
             const requests = sources.map(({ url }) => new Apify.Request({ url, uniqueKey: `${url}-${counter++}` }));
@@ -769,8 +775,8 @@ describe('Apify.RequestList', () => {
 
             const rl = await Apify.openRequestList(name, sources, options);
             expect(rl).toBeInstanceOf(Apify.RequestList);
-            expect(rl.persistStateKey.startsWith(name)).toBe(true);
-            expect(rl.persistRequestsKey.startsWith(name)).toBe(true);
+            expect(rl.persistStateKey.startsWith(SDK_KEY)).toBe(true);
+            expect(rl.persistRequestsKey.startsWith(SDK_KEY)).toBe(true);
             expect(rl.requests).toEqual(requests);
             expect(rl.isInitialized).toBe(true);
             expect(rl.keepDuplicateUrls).toBe(true);


### PR DESCRIPTION
The internal state are saved as `STATISTICS_STATE_[INDEX]`, which should be, when using just one crawler, `STATISTICS_STATE_[INDEX]`. if the crawlers retain their loading order, each one will have their persisted stats in a separate key. 
`startLogging()` now does a bit more than just actually logging, might be a misnomer. 

about the log, should it inherit from `BasicCrawler` log or be a standalone? decided to leave the `logMessage` as-is.

closes: #656 #177

~there's a caveat to this: when persisting `startedAt`, locally, if the person doesn't use `--purge`,  or when on the platform, aborting the run then resurrecting much later, the `totalMinutes` in `getCurrent()` become completely skewed. if the `startedAt` doesn't get restored upon reading from persisted state, the `perMinute` stats become skewed... which one is the lesser of two evils?~