### PR TITLE
RequestQueueLocal race condition

### DIFF
--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -818,7 +818,7 @@ export class RequestQueueLocal {
             : sgn + (base + now);
     }
 
-    async _getRequestByQueueOrderNo(queueOrderNo) {
+    async _getRequestByQueueOrderNo(queueOrderNo, fallbackToHandled=true) {
         checkParamOrThrow(queueOrderNo, 'queueOrderNo', 'Number');
         let buffer;
         let filePath;
@@ -826,7 +826,7 @@ export class RequestQueueLocal {
             filePath = this._getFilePath(queueOrderNo);
             buffer = await fs.readFile(filePath);
         } catch (err) {
-            if (err.code !== ENOENT) throw err;
+            if ((err.code !== ENOENT) || (fallbackToHandled === false)) throw err;
             filePath = this._getFilePath(queueOrderNo, true);
             buffer = await fs.readFile(filePath);
         }
@@ -931,7 +931,7 @@ export class RequestQueueLocal {
             //       Ie. the file gets listed in fs.readdir() but removed from this.queueOrderNoInProgress
             //       meanwhile causing this to fail.
             try {
-                request = await this._getRequestByQueueOrderNo(queueOrderNo);
+                request = await this._getRequestByQueueOrderNo(queueOrderNo, false);
             } catch (err) {
                 delete this.queueOrderNoInProgress[queueOrderNo];
                 this.inProgressCount--;

--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -818,7 +818,7 @@ export class RequestQueueLocal {
             : sgn + (base + now);
     }
 
-    async _getRequestByQueueOrderNo(queueOrderNo, fallbackToHandled=true) {
+    async _getRequestByQueueOrderNo(queueOrderNo, fallbackToHandled = true) {
         checkParamOrThrow(queueOrderNo, 'queueOrderNo', 'Number');
         let buffer;
         let filePath;

--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -931,6 +931,8 @@ export class RequestQueueLocal {
             //       Ie. the file gets listed in fs.readdir() but removed from this.queueOrderNoInProgress
             //       meanwhile causing this to fail.
             try {
+                // To avoid smothering ENOENT errors from  _getRequestByQueueOrderNo (which can cause a race
+                // condition with markRequestHandled) we pass false here
                 request = await this._getRequestByQueueOrderNo(queueOrderNo, false);
             } catch (err) {
                 delete this.queueOrderNoInProgress[queueOrderNo];

--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -931,8 +931,8 @@ export class RequestQueueLocal {
             //       Ie. the file gets listed in fs.readdir() but removed from this.queueOrderNoInProgress
             //       meanwhile causing this to fail.
             try {
-                // To avoid smothering ENOENT errors from  _getRequestByQueueOrderNo (which can cause a race
-                // condition with markRequestHandled) we pass false here
+                // To avoid a race condition with markRequestHandled(), we pass false here so ENOENT errors are not
+                // smothered when attempting to read a file that recently moved from pending to handled.
                 request = await this._getRequestByQueueOrderNo(queueOrderNo, false);
             } catch (err) {
                 delete this.queueOrderNoInProgress[queueOrderNo];


### PR DESCRIPTION
We tracked a bug we were seeing when crawling a reasonably large site (250K URLs) down to what looks to be a race condition within `RequestQueueLocal`. The bug causes BasicCrawler's `runTaskFunction()` to throw and prematurely terminate the crawl.

Explanation of the race condition (as far as we understand it):

1. `fetchNextRequest()` while loop picks up **queueOrderNo**

2. CheerioCrawler makes request

3. `markRequestHandled()` moves from pending to handled and deletes **queueOrderNo** from in progress

4. `fetchNextRequest()` while loop picks up _same_ **queueOrderNo** (using data from `fs.readdir` before `markRequestHandled()`  moved the file), sees it is not in progress, calls `_getRequestByQueueOrderNo()` which doesn't throw an ENOENT (because `_getRequestByQueueOrderNo()` checks both pending _and_ handled) _<--- first race condition_

5. CheerioCrawler makes request

6. Request fails (e.g. due to a server or proxy error)

7. `reclaimRequest()` deletes old queueOrderNo from in progress, issues new queueOrderNo and renames file in pending dir (the rename succeeds because it first writes the file to the old path and then atomically moves to new path)

8. `fetchNextRequest()` while loop picks up old queueOrderNo (using data from `fs.readdir` before `reclaimRequest()` renamed the file), sees it is not in progress, calls `_getRequestByQueueOrderNo()` which doesn't throw an ENOENT (because `_getRequestByQueueOrderNo()` checks both pending _and_ handled, and so picks up the original handled request mentioned in line 3 above)  _<--- second race condition_

9. CheerioCrawler makes request

10. `markRequestHandled()` tries to move from pending to handled but throws an error because the new queueOrderNo is not marked as being in progress

11. `reclaimRequest()` tries to reclaim but throws an error for the same reason (the queueOrderNo it is looking for is not in progress)

12. CheerioCrawler exits due to BasicCrawler's `runTaskFunction()` throwing an error


This PR removes the race condition by preventing `_getRequestByQueueOrderNo()` (when called by RequestQueueLocal's `fetchNextRequest()` method) from looking in the handled directory if it cannot read the request file from the pending dir. After applying it, we were able to complete multiple crawls without issue.