### PR TITLE
CheerioCrawler - reference the session pool options to underlying basic crawler

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -5,7 +5,7 @@ import { ACTOR_EVENT_NAMES } from 'apify-shared/consts';
  * Last updated on 2020-05-22.
  */
 // eslint-disable-next-line max-len
-export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36';
+export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36';
 
 /**
  * Exit codes for the actor process.

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,8 @@ import { ACTOR_EVENT_NAMES } from 'apify-shared/consts';
  * The default user agent used by `Apify.launchPuppeteer`.
  * Last updated on 2020-05-22.
  */
-export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36';
+// eslint-disable-next-line max-len
+export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36';
 
 /**
  * Exit codes for the actor process.

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -389,8 +389,8 @@ class CheerioCrawler {
             autoscaledPoolOptions,
 
             // Session pool options
-            sessionPoolOptions,
-            useSessionPool,
+            sessionPoolOptions: this.sessionPoolOptions,
+            useSessionPool: this.useSessionPool,
 
             // log
             log: this.log,


### PR DESCRIPTION
Improved reference to session pool options to point to cheerio crawler instance in the underlying basic crawler instance. Otherwise changing the options after initializing, or through the `.use()` the method won't work correctly.