### PR TITLE
PuppeteerCrawler: request headers capitalized format

### DIFF
--- a/src/puppeteer_request_interception.js
+++ b/src/puppeteer_request_interception.js
@@ -42,7 +42,7 @@ class ObservableSet extends EventEmitter {
  */
 
 /**
- * Makes puppeteer request headers more like real browser headers thanks to the letter capitalization
+ * Makes specific headers Capitalized
  * @param {object} headers
  * @returns {{}}
  */

--- a/src/puppeteer_request_interception.js
+++ b/src/puppeteer_request_interception.js
@@ -42,38 +42,18 @@ class ObservableSet extends EventEmitter {
  */
 
 /**
- * Makes specific headers Capitalized
+ * Makes all request headers capitalized to more look like in browser
  * @param {object} headers
  * @returns {{}}
  */
 const browserifyHeaders = (headers) => {
-    const browserHeaders = [
-        'upgrade-insecure-requests',
-        'accept-encoding',
-        'accept-language',
-        'sec-fetch-site',
-        'sec-fetch-mode',
-        'sec-fetch-user',
-        'sec-fetch-dest',
-        'cache-control',
-        'content-type',
-        'connection',
-        'user-agent',
-        'referer',
-        'accept',
-        'pragma',
-        'host',
-    ];
-
     const finalHeaders = {};
     // eslint-disable-next-line prefer-const
     for (let [key, value] of Object.entries(headers)) {
-        if (browserHeaders.includes(key.toLowerCase())) {
-            key = key.toLowerCase()
-                .split('-')
-                .map((str) => str.charAt(0).toUpperCase() + str.slice(1))
-                .join('-');
-        }
+        key = key.toLowerCase()
+            .split('-')
+            .map((str) => str.charAt(0).toUpperCase() + str.slice(1))
+            .join('-');
 
         finalHeaders[key] = value;
     }

--- a/src/puppeteer_request_interception.js
+++ b/src/puppeteer_request_interception.js
@@ -44,7 +44,7 @@ class ObservableSet extends EventEmitter {
 /**
  * Makes all request headers capitalized to more look like in browser
  * @param {object} headers
- * @returns {{}}
+ * @returns {object}
  */
 const browserifyHeaders = (headers) => {
     const finalHeaders = {};

--- a/test/puppeteer_request_interception.test.js
+++ b/test/puppeteer_request_interception.test.js
@@ -187,7 +187,7 @@ describe('Apify.utils.puppeteer.addInterceptRequestHandler|removeInterceptReques
                     // Override headers
                     const headers = {
                         ...request.headers(),
-                        accept: 'text/hml',
+                        accept: 'text/html',
                         'accept-language': 'en-GB',
                         'upgrade-insecure-requests': 2,
                     };
@@ -197,11 +197,22 @@ describe('Apify.utils.puppeteer.addInterceptRequestHandler|removeInterceptReques
                 const response = await page.goto(`http://${HOSTNAME}:${port}/getRawHeaders`);
                 const rawHeadersArr = JSON.parse(await response.text());
 
-                expect(rawHeadersArr.includes('Accept')).toEqual(true);
-                expect(rawHeadersArr.includes('Accept-Language')).toEqual(true);
-                expect(rawHeadersArr.includes('Upgrade-Insecure-Requests')).toEqual(true);
+                const acceptIndex = rawHeadersArr.findIndex((headerItem) => headerItem === 'Accept');
+                expect(typeof acceptIndex).toBe('number');
+                expect(rawHeadersArr[acceptIndex + 1]).toEqual('text/html');
 
-                expect(rawHeadersArr.includes('Connection')).toEqual(true); // default should be capitalized too
+                const acceptLanguageIndex = rawHeadersArr.findIndex((headerItem) => headerItem === 'Accept-Language');
+                expect(typeof acceptLanguageIndex).toBe('number');
+                expect(rawHeadersArr[acceptLanguageIndex + 1]).toEqual('en-GB');
+
+                const upgradeInsReqIndex = rawHeadersArr.findIndex((headerItem) => headerItem === 'Upgrade-Insecure-Requests');
+                expect(typeof upgradeInsReqIndex).toBe('number');
+                expect(rawHeadersArr[upgradeInsReqIndex + 1]).toEqual('2');
+
+                // defaults should be capitalized too
+                const connectionIndex = rawHeadersArr.findIndex((headerItem) => headerItem === 'Connection');
+                expect(typeof connectionIndex).toBe('number');
+                expect(rawHeadersArr[connectionIndex + 1]).toEqual('keep-alive');
             } finally {
                 await browser.close();
             }

--- a/test/puppeteer_request_interception.test.js
+++ b/test/puppeteer_request_interception.test.js
@@ -177,7 +177,7 @@ describe('Apify.utils.puppeteer.addInterceptRequestHandler|removeInterceptReques
             server.close();
         });
 
-        test('should correctly uppercase headers', async () => {
+        test('should correctly capitalize headers', async () => {
             const browser = await Apify.launchPuppeteer({ headless: true });
 
             try {
@@ -200,6 +200,8 @@ describe('Apify.utils.puppeteer.addInterceptRequestHandler|removeInterceptReques
                 expect(rawHeadersArr.includes('Accept')).toEqual(true);
                 expect(rawHeadersArr.includes('Accept-Language')).toEqual(true);
                 expect(rawHeadersArr.includes('Upgrade-Insecure-Requests')).toEqual(true);
+
+                expect(rawHeadersArr.includes('Connection')).toEqual(true); // default should be capitalized too
             } finally {
                 await browser.close();
             }


### PR DESCRIPTION
Changed format of puppeteer request `headers` - now capitalized formatting is used because it is more like real browser headers