### PR TITLE
Fixed default persistCookiesPerSession

### DIFF
--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -251,7 +251,7 @@ class BrowserCrawler extends BasicCrawler {
             handlePageFunction,
             handlePageTimeoutSecs = 60,
             gotoFunction,
-            persistCookiesPerSession = true,
+            persistCookiesPerSession,
             useSessionPool = true,
             sessionPoolOptions,
             proxyConfiguration,
@@ -279,13 +279,14 @@ class BrowserCrawler extends BasicCrawler {
         this.gotoFunction = gotoFunction;
         this.defaultGotoOptions = {};
 
-        this.persistCookiesPerSession = persistCookiesPerSession;
         this.proxyConfiguration = proxyConfiguration;
 
         this.preNavigationHooks = preNavigationHooks;
         this.postNavigationHooks = postNavigationHooks;
 
         if (useSessionPool) {
+            this.persistCookiesPerSession = persistCookiesPerSession || true;
+
             this.sessionPool = new SessionPool({
                 ...sessionPoolOptions,
                 log: this.log,

--- a/test/crawlers/browser_crawler.test.js
+++ b/test/crawlers/browser_crawler.test.js
@@ -315,6 +315,25 @@ describe('BrowserCrawler', () => {
         goToPageSessions.forEach((session) => expect(session.constructor.name).toEqual('Session'));
     });
 
+    test('should not throw without SessionPool', async () => {
+        const requestList = new Apify.RequestList({
+            sources: [
+                { url: 'http://example.com/?q=1' },
+            ],
+        });
+        const browserCrawler = new Apify.BrowserCrawler({
+            browserPoolOptions: {
+                browserPlugins: [puppeteerPlugin],
+            },
+            requestList,
+            useSessionPool: false,
+            handlePageFunction: async () => {},
+
+        });
+
+        expect(browserCrawler).toBeDefined();
+    });
+
     test('should persist cookies per session', async () => {
         const requestList = new Apify.RequestList({
             sources: [


### PR DESCRIPTION
We have to set the default only if the sessionPool is on. Otherwise it will throw an error.