### PR TITLE
fix inconsistency between puppeteer and sessionPool cookies, add tests

### DIFF
--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -251,7 +251,7 @@ class BrowserCrawler extends BasicCrawler {
             handlePageFunction,
             handlePageTimeoutSecs = 60,
             gotoFunction,
-            persistCookiesPerSession = true,
+            persistCookiesPerSession,
             useSessionPool = true,
             sessionPoolOptions,
             proxyConfiguration,
@@ -261,6 +261,7 @@ class BrowserCrawler extends BasicCrawler {
             ...basicCrawlerOptions
         } = options;
 
+        // Cookies should be persisted per session only if session pool is used
         if (!useSessionPool && persistCookiesPerSession) {
             throw new Error('You cannot use "persistCookiesPerSession" without "useSessionPool" set to true.');
         }
@@ -285,7 +286,7 @@ class BrowserCrawler extends BasicCrawler {
         this.postNavigationHooks = postNavigationHooks;
 
         if (useSessionPool) {
-            this.persistCookiesPerSession = persistCookiesPerSession;
+            this.persistCookiesPerSession = persistCookiesPerSession !== undefined ? persistCookiesPerSession : true;
 
             this.sessionPool = new SessionPool({
                 ...sessionPoolOptions,
@@ -294,6 +295,8 @@ class BrowserCrawler extends BasicCrawler {
 
             // Assuming there are not more than 20 browsers running at once;
             this.sessionPool.setMaxListeners(20);
+        } else {
+            this.persistCookiesPerSession = false;
         }
 
         const { preLaunchHooks = [], postLaunchHooks = [], ...rest } = browserPoolOptions;

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -251,7 +251,7 @@ class BrowserCrawler extends BasicCrawler {
             handlePageFunction,
             handlePageTimeoutSecs = 60,
             gotoFunction,
-            persistCookiesPerSession,
+            persistCookiesPerSession = true,
             useSessionPool = true,
             sessionPoolOptions,
             proxyConfiguration,
@@ -285,7 +285,7 @@ class BrowserCrawler extends BasicCrawler {
         this.postNavigationHooks = postNavigationHooks;
 
         if (useSessionPool) {
-            this.persistCookiesPerSession = persistCookiesPerSession || true;
+            this.persistCookiesPerSession = persistCookiesPerSession;
 
             this.sessionPool = new SessionPool({
                 ...sessionPoolOptions,
@@ -326,9 +326,9 @@ class BrowserCrawler extends BasicCrawler {
 
         const { request, session } = crawlingContext;
 
-        if (this.persistCookiesPerSession) {
-            const cookies = crawlingContext.session.getPuppeteerCookies(request.url);
-            await crawlingContext.browserController.setCookies(page, cookies);
+        const sessionCookies = crawlingContext.session.getPuppeteerCookies(request.url);
+        if (sessionCookies.length) {
+            await crawlingContext.browserController.setCookies(page, sessionCookies);
         }
 
         try {

--- a/src/session_pool/session.js
+++ b/src/session_pool/session.js
@@ -305,7 +305,7 @@ export class Session {
      * @private
      */
     _puppeteerCookieToTough(puppeteerCookie) {
-        const isExpiresValid = puppeteerCookie.expires && typeof puppeteerCookie.expires === 'number';
+        const isExpiresValid = puppeteerCookie.expires && typeof puppeteerCookie.expires === 'number' && puppeteerCookie.expires !== -1;
         const expires = isExpiresValid ? new Date(puppeteerCookie.expires * 1000) : this._getDefaultCookieExpirationDate(this.maxAgeSecs);
         const domain = typeof puppeteerCookie.domain === 'string' && puppeteerCookie.domain.startsWith('.')
             ? puppeteerCookie.domain.slice(1)

--- a/src/session_pool/session.js
+++ b/src/session_pool/session.js
@@ -305,7 +305,7 @@ export class Session {
      * @private
      */
     _puppeteerCookieToTough(puppeteerCookie) {
-        const isExpiresValid = puppeteerCookie.expires && typeof puppeteerCookie.expires === 'number' && puppeteerCookie.expires !== -1;
+        const isExpiresValid = puppeteerCookie.expires && typeof puppeteerCookie.expires === 'number' && puppeteerCookie.expires > 0;
         const expires = isExpiresValid ? new Date(puppeteerCookie.expires * 1000) : this._getDefaultCookieExpirationDate(this.maxAgeSecs);
         const domain = typeof puppeteerCookie.domain === 'string' && puppeteerCookie.domain.startsWith('.')
             ? puppeteerCookie.domain.slice(1)

--- a/src/session_pool/session.js
+++ b/src/session_pool/session.js
@@ -331,7 +331,7 @@ export class Session {
         return {
             name: toughCookie.key,
             value: toughCookie.value,
-            expires: new Date(toughCookie.expires).getTime(),
+            expires: new Date(toughCookie.expires).getTime() / 1000,
             domain: toughCookie.domain,
             path: toughCookie.path,
             secure: toughCookie.secure,

--- a/src/session_pool/session.js
+++ b/src/session_pool/session.js
@@ -331,6 +331,7 @@ export class Session {
         return {
             name: toughCookie.key,
             value: toughCookie.value,
+            // Puppeteer and Playwright expect 'expires' to be 'Unix time in seconds', not ms
             expires: new Date(toughCookie.expires).getTime() / 1000,
             domain: toughCookie.domain,
             path: toughCookie.path,

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -738,7 +738,7 @@ describe('CheerioCrawler', () => {
                     },
                 });
             } catch (e) {
-                expect(e.message).toEqual('Cannot use "options.persistCookiesPerSession" without "options.useSessionPool"');
+                expect(e.message).toEqual('You cannot use "persistCookiesPerSession" without "useSessionPool" set to true.');
             }
         });
 

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -217,6 +217,7 @@ describe('PuppeteerCrawler', () => {
         const puppeteerCrawler = new Apify.PuppeteerCrawler({
             requestList,
             useSessionPool: true,
+            persistCookiesPerSession: true,
             sessionPoolOptions: {
                 createSessionFunction: (sessionPool) => {
                     const session = new Apify.Session({ sessionPool });

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -200,4 +200,38 @@ describe('PuppeteerCrawler', () => {
 
         expect(loadedUserAgent).toEqual(opts.userAgent);
     });
+
+    test('should set cookies assigned to session to page', async () => {
+        const cookies = [
+            {
+                name: 'example_cookie_name',
+                domain: '.example.com',
+                value: 'example_cookie_value',
+                expires: -1,
+            },
+        ];
+
+        let pageCookies;
+        let sessionCookies;
+
+        const puppeteerCrawler = new Apify.PuppeteerCrawler({
+            requestList,
+            useSessionPool: true,
+            sessionPoolOptions: {
+                createSessionFunction: (sessionPool) => {
+                    const session = new Apify.Session({ sessionPool });
+                    session.setPuppeteerCookies(cookies, 'http://www.example.com');
+                    return session;
+                },
+            },
+            handlePageFunction: async ({ page, session }) => {
+                pageCookies = await page.cookies().then((cks) => cks.map((c) => `${c.name}=${c.value}`).join('; '));
+                sessionCookies = session.getCookieString('http://www.example.com');
+            },
+        });
+
+        await puppeteerCrawler.run();
+
+        expect(pageCookies).toEqual(sessionCookies);
+    });
 });

--- a/test/session_pool/session.test.js
+++ b/test/session_pool/session.test.js
@@ -202,6 +202,17 @@ describe('Session - testing session behaviour ', () => {
         expect(session.getCookieString(url)).toBe('cookie1=my-cookie; cookie2=your-cookie');
     });
 
+    test('setPuppeteerCookies should work for session (with expiration date: -1) cookies', () => {
+        const url = 'https://example.com';
+        const cookies = [
+            { name: 'session_cookie', value: 'session-cookie-value', expires: -1 },
+        ];
+
+        session = new Session({ sessionPool });
+        session.setPuppeteerCookies(cookies, url);
+        expect(session.getCookieString(url)).toBe('session_cookie=session-cookie-value');
+    });
+
     test('setPuppeteerCookies works with leading dots in domains', () => {
         const url = 'https://www.example.com';
         const cookies = [


### PR DESCRIPTION
For some cookies without an expiration date (session cookies), puppeteer would return `expires: -1` (chrome would show `Expires: Session` for these). Puppeteer methods would work completely fine while saving such cookies to session leads to some inconsistent behavior - either cookie would not be set to a session or it would not be then set to the page.

Fixes #922