### PR TITLE
fix Apify.call() output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.1.0 / 2021/03/XX
+====================
+- Fix `Apify.call()` and `Apify.callTask()` output - make it backwards compatible with previous versions of the client.
+
 1.0.2 / 2021/03/05
 ====================
 - Add the ability to override `ProxyConfiguration` status check URL with the `APIFY_PROXY_STATUS_URL` env var.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "The scalable web crawling and scraping library for JavaScript/Node.js. Enables development of data extraction and web automation jobs (not only) with headless Chrome and Puppeteer.",
     "engines": {
         "node": ">=10.17.0"

--- a/src/actor.js
+++ b/src/actor.js
@@ -358,9 +358,9 @@ export const call = async (actId, input, options = {}) => {
     let getRecordOptions = {};
     if (disableBodyParser) getRecordOptions = { buffer: true };
 
-    const output = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT', getRecordOptions);
+    const { value: body, contentType } = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT', getRecordOptions);
 
-    return { ...run, output };
+    return { ...run, output: { contentType, body } };
 };
 
 /**
@@ -476,9 +476,9 @@ export const callTask = async (taskId, input, options = {}) => {
     let getRecordOptions = {};
     if (disableBodyParser) getRecordOptions = { buffer: true };
 
-    const output = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT', getRecordOptions);
+    const { value: body, contentType } = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('OUTPUT', getRecordOptions);
 
-    return { ...run, output };
+    return { ...run, output: { contentType, body } };
 };
 
 function isRunUnsuccessful(status) {

--- a/test/actor.test.js
+++ b/test/actor.test.js
@@ -240,6 +240,8 @@ describe('Apify.call()', () => {
     const defaultKeyValueStoreId = 'some-store-id';
     const input = 'something';
     const contentType = 'text/plain';
+    const outputKey = 'OUTPUT';
+    const outputValue = 'some-output';
     const build = 'xxx';
 
     const run = { id: 'some-run-id', actId, defaultKeyValueStoreId };
@@ -248,8 +250,8 @@ describe('Apify.call()', () => {
     const runningRun = { ...run, status: ACT_JOB_STATUSES.RUNNING };
     const readyRun = { ...run, status: ACT_JOB_STATUSES.READY };
 
-    const output = { contentType, input: 'some-output' };
-    const expected = { ...finishedRun, output };
+    const output = { contentType, key: outputKey, value: outputValue };
+    const expected = { ...finishedRun, output: { contentType, body: outputValue } };
 
     test('works as expected', async () => {
         const memoryMbytes = 1024;
@@ -392,8 +394,11 @@ describe('Apify.callTask()', () => {
     const runningRun = { ...run, status: ACT_JOB_STATUSES.RUNNING };
     const finishedRun = { ...run, status: ACT_JOB_STATUSES.SUCCEEDED };
     const failedRun = { ...run, status: ACT_JOB_STATUSES.ABORTED };
-    const output = { contentType: 'application/json', body: 'some-output' };
-    const expected = { ...finishedRun, output };
+    const contentType = 'application/json';
+    const outputKey = 'OUTPUT';
+    const outputValue = 'some-output';
+    const output = { contentType, key: outputKey, value: outputValue };
+    const expected = { ...finishedRun, output: { contentType, body: outputValue } };
     const input = { foo: 'bar' };
     const memoryMbytes = 256;
     const timeoutSecs = 60;


### PR DESCRIPTION
Fixes #951 (keep `{ contentType, body }` as `Apify.call()` output (instead of `{ key, value, contentType }`, same for `Apify.callTask()`).