### PR TITLE
Made "npm run clean" Windows-compatible

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     test:
         name: Test
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
 
         strategy:
             fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   build_and_test:
     name: Build & Test
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       -
         name: Cache Node Modules
-        if: ${{ matrix.node-version == 14 }}
+        if: ${{ matrix.node-version == 14  && matrix.os == 'ubuntu-latest' }}
         uses: actions/cache@v2
         with:
           path: |

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "test": "npm run build && jest --silent",
         "prepare": "npm run build",
         "prepublishOnly": "(test $CI || (echo \"Publishing is reserved to CI!\"; exit 1))",
-        "clean": "rm -rf ./build ./types",
+        "clean": "shx rm -rf ./build ./types",
         "lint": "eslint ./src ./test",
         "lint:fix": "eslint ./src ./test --ext .js,.jsx --fix"
     },
@@ -112,6 +112,7 @@
         "prettier": "^2.1.2",
         "proxy": "^1.0.2",
         "puppeteer": "8.0.0",
+        "shx": "^0.3.3",
         "sinon": "^9.2.0",
         "sinon-stub-promise": "^4.0.0",
         "socket.io-client": "^3.0.3",


### PR DESCRIPTION
Made the "npm run clean" Windowns-compatible using "[shx](https://github.com/shelljs/shx)".

Additionally, I created a PR on "apify/ps-tree" repository for making "Apify.getMemoryInfo" correctly return "RSS "in "mainProcessBytes". By this PR, I think the 4 failed test cases in "test/utils.test.js" will become able to be passed.
https://github.com/apify/ps-tree/pull/1
Could someone also review it?