### PR TITLE
chore: bump storage-local, node 16

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [ 10, 12, 14, 15 ]
+                node-version: [ 10, 12, 14, 15, 16 ]
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10, 12, 14, 15]
+        node-version: [10, 12, 14, 15, 16]
 
     steps:
       -

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dependencies": {
         "@apify/http-request": "^2.1.1",
         "@apify/ps-tree": "^1.1.3",
-        "@apify/storage-local": "^2.0.0",
+        "@apify/storage-local": "^2.0.1-beta.0",
         "@types/cheerio": "^0.22.28",
         "@types/domhandler": "^2.4.1",
         "@types/node": "^14",


### PR DESCRIPTION
I need the bumped version of storage local to build the images without the unnecessary `node-gyp` dependencies, which are not present in the underlying node images. I also added the node 16 to the actions.