### PR TITLE
fix: incognito pages and user data dir

### DIFF
--- a/src/browser_launchers/browser_launcher.js
+++ b/src/browser_launchers/browser_launcher.js
@@ -30,9 +30,10 @@ import { BrowserPlugin } from './browser_plugin'; // eslint-disable-line no-unus
  */
 export default class BrowserLauncher {
     static optionsShape = {
-        launcher: ow.object,
         proxyUrl: ow.optional.string.url,
         useChrome: ow.optional.boolean,
+        useIncognitoPages: ow.optional.boolean,
+        userDataDir: ow.optional.string,
         launchOptions: ow.optional.object,
     }
 
@@ -64,13 +65,12 @@ export default class BrowserLauncher {
     * All `BrowserLauncher` parameters are passed via an launchContext object.
     */
     constructor(launchContext) {
-        ow(launchContext, 'BrowserLauncherOptions', ow.object.exactShape(BrowserLauncher.optionsShape));
-
         const {
             launcher,
             proxyUrl,
             useChrome,
             launchOptions = {},
+            ...otherLaunchContextProps
         } = launchContext;
 
         this._validateProxyUrl(proxyUrl);
@@ -82,6 +82,7 @@ export default class BrowserLauncher {
         this.useChrome = useChrome;
         /** @type {Object<string, *>} */
         this.launchOptions = launchOptions;
+        this.otherLaunchContextProps = otherLaunchContextProps;
 
         /** @type {BrowserPlugin} */
         this.Plugin = null; // to be provided by child classes;
@@ -97,6 +98,7 @@ export default class BrowserLauncher {
             {
                 proxyUrl: this.proxyUrl,
                 launchOptions: this.createLaunchOptions(),
+                ...this.otherLaunchContextProps,
             },
         );
     }
@@ -108,10 +110,7 @@ export default class BrowserLauncher {
     async launch() {
         const plugin = this.createBrowserPlugin();
         const context = await plugin.createLaunchContext();
-
-        const browser = await plugin.launch(context);
-
-        return browser;
+        return plugin.launch(context);
     }
 
     /**

--- a/test/browser_launchers/playwright_launcher.test.js
+++ b/test/browser_launchers/playwright_launcher.test.js
@@ -23,7 +23,7 @@ beforeAll(() => {
     process.env[ENV_VARS.HEADLESS] = '1';
 
     // Find free port for the proxy
-    return portastic.find({ min: 50000, max: 50100 }).then((ports) => {
+    return portastic.find({ min: 50000, max: 50099 }).then((ports) => {
         return new Promise((resolve, reject) => {
             const httpServer = http.createServer();
 
@@ -190,7 +190,7 @@ describe('Apify.launchPlaywright()', () => {
             expect(plugin.launchOptions.executablePath).toBe(utils.getTypicalChromeExecutablePath());
         });
 
-        test('allows to be overriden', () => {
+        test('allows to be overridden', () => {
             const newPath = 'newPath';
 
             const launcher = new PlaywrightLauncher({
@@ -219,5 +219,39 @@ describe('Apify.launchPlaywright()', () => {
                 if (browser) await browser.close();
             }
         });
+    });
+
+    test('supports useIncognitoPages: true', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPlaywright({
+                useIncognitoPages: true,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.context();
+            const page2 = await browser.newPage();
+            const context2 = page2.context();
+            expect(context1).not.toBe(context2);
+        } finally {
+            if (browser) await browser.close();
+        }
+    });
+
+    test('supports useIncognitoPages: false', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPlaywright({
+                useIncognitoPages: false,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.context();
+            const page2 = await browser.newPage();
+            const context2 = page2.context();
+            expect(context1).toBe(context2);
+        } finally {
+            if (browser) await browser.close();
+        }
     });
 });

--- a/test/browser_launchers/puppeteer_launcher.test.js
+++ b/test/browser_launchers/puppeteer_launcher.test.js
@@ -21,7 +21,7 @@ beforeAll(() => {
     process.env[ENV_VARS.HEADLESS] = '1';
 
     // Find free port for the proxy
-    return portastic.find({ min: 50000, max: 50100 }).then((ports) => {
+    return portastic.find({ min: 50100, max: 50199 }).then((ports) => {
         return new Promise((resolve, reject) => {
             const httpServer = http.createServer();
 
@@ -118,7 +118,7 @@ describe('Apify.launchPuppeteer()', () => {
         let page;
 
         // Test headless parameter
-        process.env[ENV_VARS.HEADLESS] = false;
+        process.env[ENV_VARS.HEADLESS] = 0;
 
         return Apify.launchPuppeteer({
             launchOptions: { headless: true },
@@ -213,6 +213,40 @@ describe('Apify.launchPuppeteer()', () => {
                 },
                 launchOptions: { headless: true },
             });
+        } finally {
+            if (browser) await browser.close();
+        }
+    });
+
+    test('supports useIncognitoPages: true', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPuppeteer({
+                useIncognitoPages: true,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.browserContext();
+            const page2 = await browser.newPage();
+            const context2 = page2.browserContext();
+            expect(context1).not.toBe(context2);
+        } finally {
+            if (browser) await browser.close();
+        }
+    });
+
+    test('supports useIncognitoPages: false', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPuppeteer({
+                useIncognitoPages: false,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.browserContext();
+            const page2 = await browser.newPage();
+            const context2 = page2.browserContext();
+            expect(context1).toBe(context2);
         } finally {
             if (browser) await browser.close();
         }


### PR DESCRIPTION
When trying out Playwright I found that neither the `userDataDir` nor `useIncognitoPages` options of `browser-pool` work in the SDK. I attempted a quick fix, but apparently there is also a problem in the design, because `useIncognitoPages` works on the plugin level for Playwright (hence the passing tests), but on the `BrowserController` level in `Puppeteer`. Hence the failing test, because `Apify.launchPuppeteer` does not work with `BrowserController` at all.

We need to add more tests to make sure this works in all cases:

- [x] `useIncognitoPages: false` works in `Apify.launchPlaywright`
- [x] `useIncognitoPages: true` works in `Apify.launchPlaywright`
- [x] `useIncognitoPages: false` works in `Apify.launchPuppeteer`
- [ ]  `useIncognitoPages: true` works in `Apify.launchPuppeteer`
- [ ] `userDataDir` works in `PlaywrightCrawler`
- [ ] `userDataDir` works in `PlaywrightCrawler`
- [ ] `userDataDir` works in `PuppeteerCrawler`
- [ ]  `userDataDir` works in `PuppeteerCrawler`