### PR TITLE
chore: define puppeteer and playwright as optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "@types/cheerio": "^0.22.28",
         "@types/domhandler": "^2.4.1",
         "@types/node": "^14",
-        "@types/puppeteer": "^5.4.3",
         "@types/socket.io": "^2.1.13",
         "@types/tough-cookie": "^4.0.0",
         "apify-client": "^1.0.3",
@@ -79,6 +78,18 @@
         "tough-cookie": "^4.0.0",
         "underscore": "^1.13.0",
         "ws": "^7.3.1"
+    },
+    "peerDependencies": {
+        "playwright": "^1.11.0",
+        "puppeteer": "^9.0.0"
+    },
+    "peerDependenciesMeta": {
+        "playwright": {
+            "optional": true
+        },
+        "puppeteer": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@apify/eslint-config": "^0.1.3",


### PR DESCRIPTION
Also removes `@types/puppeteer` as they are now included in the `puppeteer` package.

Closes #1005