### PR TITLE
chore: Rename GitHub workflow event for building node images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           token: ${{ secrets.TRIGGER_DOCKER_IMAGE_BUILD_TOKEN }}
           repository: apify/apify-actor-docker
-          event-type: build-images
+          event-type: build-node-images
           client-payload: >
             {
               "release_tag": "${{ env.RELEASE_TAG }}",


### PR DESCRIPTION
A [PR in `apify-actor-docker`](https://github.com/apify/apify-actor-docker/pull/57) renames the repository dispatch event for building Node images with the Apify SDK, so this PR changes the name of the event when calling that repository dispatch from here.

Please merge only after that PR is merged, ideally immediately after, so the building of the actor images with Apify SDK is not broken.