### PR TITLE
feat: add `forceUrlEncoding` option to `requestAsBrowser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ await dataset.pushData({ myValue: 123 });
 - Update `puppeteer` and `playwright` to match stable Chrome (90).
 - Fix support for building TypeScript projects that depend on the SDK.
 - add `taskTimeoutSecs` to allow control over timeout of `AutoscaledPool` tasks
+- fallback to encoded URL in `requestAsBrowser`
 
 1.2.1 / 2021/05/14
 ====================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ await dataset.pushData({ myValue: 123 });
 - Update `puppeteer` and `playwright` to match stable Chrome (90).
 - Fix support for building TypeScript projects that depend on the SDK.
 - add `taskTimeoutSecs` to allow control over timeout of `AutoscaledPool` tasks
-- add `forceUrlEncoding` to `CheerioCrawler` and `requestAsBrowser` options
+- add `forceUrlEncoding` to `requestAsBrowser` options
+- add `preNavigationHooks` and `postNavigationHooks` to `CheerioCrawler`
 
 1.2.1 / 2021/05/14
 ====================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 1.3.0 / BETA
 ====================
+
+## Navigation hooks in `CheerioCrawler`
+
+`CheerioCrawler` downloads the web pages using the `requestAsBrowser` utility function.
+As opposed to the browser based crawlers that are automatically encoding the URLs, the
+`requestAsBrowser` function will not do so. We either need to manually encode the URLs
+via `encodeURI()` function, or set `forceUrlEncoding: true` in the `requestAsBrowserOptions`,
+which will automatically encode all the URLs before accessing them.
+
+> We can either use `forceUrlEncoding` or encode manually, but not both - it would
+> result in double encoding and therefore lead to invalid URLs.
+
+We can use the `preNavigationHooks` to adjust `requestAsBrowserOptions`:
+
+```
+preNavigationHooks: [
+    (crawlingContext, requestAsBrowserOptions) => {
+        requestAsBrowserOptions.forceUrlEncoding = true;
+    }
+]
+```
+
+## `Apify` class and `Configuration`
+
 Adds two new named exports:
 
 - `Configuration` class that serves as the main configuration holder, replacing explicit usage of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ await dataset.pushData({ myValue: 123 });
 - Update `puppeteer` and `playwright` to match stable Chrome (90).
 - Fix support for building TypeScript projects that depend on the SDK.
 - add `taskTimeoutSecs` to allow control over timeout of `AutoscaledPool` tasks
-- fallback to encoded URL in `requestAsBrowser`
+- add `forceUrlEncoding` to `CheerioCrawler` and `requestAsBrowser` options
 
 1.2.1 / 2021/05/14
 ====================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ await dataset.pushData({ myValue: 123 });
 - add `taskTimeoutSecs` to allow control over timeout of `AutoscaledPool` tasks
 - add `forceUrlEncoding` to `requestAsBrowser` options
 - add `preNavigationHooks` and `postNavigationHooks` to `CheerioCrawler`
+- deprecated `prepareRequestFunction` and `postResponseFunction` methods of `CheerioCrawler`
 
 1.2.1 / 2021/05/14
 ====================

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     testRunner: 'jest-circus/runner',
     verbose: false,
     rootDir: path.join(__dirname, './'),
-    testTimeout: 30e3,
+    testTimeout: 60e3,
     maxWorkers: 3,
     testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
     transform: {

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -634,6 +634,21 @@ export class BasicCrawler {
     }
 
     /**
+     * @param {Array<Hook>} hooks
+     * @param  {*} args
+     * @ignore
+     * @protected
+     * @internal
+     */
+    async _executeHooks(hooks, ...args) {
+        if (Array.isArray(hooks) && hooks.length) {
+            for (const hook of hooks) {
+                await hook(...args);
+            }
+        }
+    }
+
+    /**
      * Function for cleaning up after all request are processed.
      * @ignore
      */

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -536,21 +536,6 @@ export default class BrowserCrawler extends BasicCrawler {
     }
 
     /**
-     * @param {Array<Hook>} hooks
-     * @param  {*} args
-     * @ignore
-     * @protected
-     * @internal
-     */
-    async _executeHooks(hooks, ...args) {
-        if (Array.isArray(hooks) && hooks.length) {
-            for (const hook of hooks) {
-                await hook(...args);
-            }
-        }
-    }
-
-    /**
      * Function for cleaning up after all request are processed.
      * @ignore
      */

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -130,7 +130,7 @@ import { AutoscaledPoolOptions } from '../autoscaling/autoscaled_pool';
  * ```
  * @property {Array<Hook>} [postNavigationHooks]
  *   Async functions that are sequentially evaluated after the navigation. Good for checking if the navigation was successful.
- *   The function accepts `crawlingContext` as an only parameter.
+ *   The function accepts `crawlingContext` as the only parameter.
  *   Example:
  * ```
  * postNavigationHooks: [

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -298,11 +298,16 @@ const CHEERIO_OPTIMIZED_AUTOSCALED_POOL_OPTIONS = {
  *
  * The crawler finishes when there are no more {@link Request} objects to crawl.
  *
- * `CheerioCrawler` downloads the web pages using the {@link utils#requestAsBrowser} utility function.
+ * `CheerioCrawler` downloads the web pages using the `{@link utils#requestAsBrowser}` utility function.
  * As opposed to the browser based crawlers that are automatically encoding the URLs, the
- * {@link utils#requestAsBrowser} function will not do so. We either need to manually encode the URLs
- * via `encodeURI()` function manually, or pass `forceUrlEncoding: true` in the `requestAsBrowserOptions`, which
- * will automatically encode all the URLs before accessing them.
+ * `{@link utils#requestAsBrowser}` function will not do so. We either need to manually encode the URLs
+ * via `encodeURI()` function, or set `forceUrlEncoding: true` in the `requestAsBrowserOptions`,
+ * which will automatically encode all the URLs before accessing them.
+ *
+ * > We can either use `forceUrlEncoding` or encode manually, but not both - it would
+ * > result in double encoding and therefore lead to invalid URLs.
+ *
+ * We can use the `preNavigationHooks` to adjust `requestAsBrowserOptions`:
  *
  * ```
  * preNavigationHooks: [
@@ -311,9 +316,6 @@ const CHEERIO_OPTIMIZED_AUTOSCALED_POOL_OPTIONS = {
  *     }
  * ]
  * ```
- *
- * > We can either use `forceUrlEncoding` or encode manually, but not both - it would result in
- * > double encoding and therefore lead to invalid URLs.
  *
  * By default, `CheerioCrawler` only processes web pages with the `text/html`
  * and `application/xhtml+xml` MIME content types (as reported by the `Content-Type` HTTP header),

--- a/src/crawlers/playwright_crawler.js
+++ b/src/crawlers/playwright_crawler.js
@@ -117,7 +117,7 @@ import { gotoExtended } from '../playwright_utils';
  * ```
  * @property {Array<PlaywrightHook>} [postNavigationHooks]
  *   Async functions that are sequentially evaluated after the navigation. Good for checking if the navigation was successful.
- *   The function accepts `crawlingContext` as an only parameter.
+ *   The function accepts `crawlingContext` as the only parameter.
  *   Example:
  * ```
  * postNavigationHooks: [

--- a/src/crawlers/puppeteer_crawler.js
+++ b/src/crawlers/puppeteer_crawler.js
@@ -118,7 +118,7 @@ import { BrowserPoolOptions } from 'browser-pool';
  * ```
  * @property {Array<PuppeteerHook>} [postNavigationHooks]
  *   Async functions that are sequentially evaluated after the navigation. Good for checking if the navigation was successful.
- *   The function accepts `crawlingContext` as an only parameter.
+ *   The function accepts `crawlingContext` as the only parameter.
  *   Example:
  * ```
  * postNavigationHooks: [

--- a/src/utils_request.js
+++ b/src/utils_request.js
@@ -180,14 +180,38 @@ export const requestAsBrowser = async (options = {}) => {
         };
     }
 
-    if (!gotScrapingOptions.isStream) return gotScraping(gotScrapingOptions);
+    if (!gotScrapingOptions.isStream) {
+        try {
+            return await gotScraping(gotScrapingOptions);
+        } catch (err) {
+            if (gotScrapingOptions.forceEncoded || gotScrapingOptions.url === encodeURI(gotScrapingOptions.url)) {
+                throw err; // already tried or wouldn't help, rethrow
+            }
+
+            // retry with encoded url
+            gotScrapingOptions.url = encodeURI(gotScrapingOptions.url);
+            gotScrapingOptions.forceEncoded = true;
+
+            return gotScraping(gotScrapingOptions);
+        }
+    }
 
     // abortFunction must be handled separately for streams :(
     const duplexStream = await gotScraping(gotScrapingOptions);
     ensureRequestIsDispatched(duplexStream, gotScrapingOptions);
     return new Promise((resolve, reject) => {
         duplexStream
-            .on('error', reject)
+            .on('error', (err) => {
+                if (gotScrapingOptions.forceEncoded || gotScrapingOptions.url === encodeURI(gotScrapingOptions.url)) {
+                    return reject(err); // already tried or wouldn't help, rethrow
+                }
+
+                gotScrapingOptions.url = encodeURI(gotScrapingOptions.url);
+                gotScrapingOptions.forceEncoded = true;
+
+                // retry with encoded url
+                requestAsBrowser(gotScrapingOptions).then(resolve, reject);
+            })
             .on('response', (res) => {
                 try {
                     const shouldAbort = abortFunction(res);

--- a/src/utils_request.js
+++ b/src/utils_request.js
@@ -49,6 +49,8 @@ import { IncomingMessage } from 'http';
  *  expect HTTP2 connections, because browsers use HTTP2 by default. It will automatically downgrade
  *  to HTTP/1.1 for websites that do not support HTTP2. For Node 10 this option is always set to `false`
  *  because Node 10 does not support HTTP2 very well. Upgrade to Node 12 for better performance.
+ * @property {boolean} [forceUrlEncoding]
+ *   Automatically encode URLs via `encodeURI()` before resolving them.
  */
 
 /**

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -212,7 +212,11 @@ describe('CheerioCrawler', () => {
             maxConcurrency: 2,
             handlePageFunction,
             handleFailedRequestFunction: ({ request }) => failed.push(request),
-            forceUrlEncoding: true,
+            preNavigationHooks: [
+                (_, gotoOptions) => {
+                    gotoOptions.forceUrlEncoding = true;
+                },
+            ],
         });
 
         await cheerioCrawler.run();

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -190,6 +190,40 @@ describe('CheerioCrawler', () => {
         expect(success.url).toEqual(MODIFIED_URL);
     });
 
+    test('should work with not encoded urls', async () => {
+        const sources = [
+            { url: `http://${HOST}:${port}/mirror?q=abc` },
+            { url: `http://${HOST}:${port}/mirror?q=%20` },
+            { url: `http://${HOST}:${port}/mirror?q=%cf` },
+        ];
+        const requestList = new Apify.RequestList({ sources });
+        await requestList.initialize();
+        const processed = [];
+        const failed = [];
+        const handlePageFunction = async ({ $, body, request }) => {
+            request.userData.title = $('title').text();
+            request.userData.body = body;
+            processed.push(request);
+        };
+
+        const cheerioCrawler = new Apify.CheerioCrawler({
+            requestList,
+            minConcurrency: 2,
+            maxConcurrency: 2,
+            handlePageFunction,
+            handleFailedRequestFunction: ({ request }) => failed.push(request),
+        });
+
+        await cheerioCrawler.run();
+
+        expect(processed).toHaveLength(3);
+        expect(failed).toHaveLength(0);
+
+        expect(processed[0].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=abc`);
+        expect(processed[1].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=%20`);
+        expect(processed[2].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=%25cf`);
+    });
+
     test('postResponseFunction should work', async () => {
         const sources = ['http://example.com/'];
         const requestList = await Apify.openRequestList(null, sources.slice());

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -193,7 +193,7 @@ describe('CheerioCrawler', () => {
     test('should work with not encoded urls', async () => {
         const sources = [
             { url: `http://${HOST}:${port}/mirror?q=abc` },
-            { url: `http://${HOST}:${port}/mirror?q=%20` },
+            { url: `http://${HOST}:${port}/mirror?q=%` },
             { url: `http://${HOST}:${port}/mirror?q=%cf` },
         ];
         const requestList = new Apify.RequestList({ sources });
@@ -212,6 +212,7 @@ describe('CheerioCrawler', () => {
             maxConcurrency: 2,
             handlePageFunction,
             handleFailedRequestFunction: ({ request }) => failed.push(request),
+            forceUrlEncoding: true,
         });
 
         await cheerioCrawler.run();
@@ -220,7 +221,7 @@ describe('CheerioCrawler', () => {
         expect(failed).toHaveLength(0);
 
         expect(processed[0].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=abc`);
-        expect(processed[1].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=%20`);
+        expect(processed[1].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=%25`);
         expect(processed[2].loadedUrl).toBe(`http://${HOST}:${port}/mirror?q=%25cf`);
     });
 

--- a/test/utils_request.test.js
+++ b/test/utils_request.test.js
@@ -104,25 +104,28 @@ describe('Apify.utils_request', () => {
         });
 
         const testQueries = [
-            ['abc', 'abc'],
-            ['%20', ' '],
-            ['%cf', '%cf'],
-            ['helios-–-the-primordial-sun', 'helios-–-the-primordial-sun'],
-            ['helios-%E2%80%93-the-primordial-sun', 'helios-–-the-primordial-sun'],
+            ['abc', 'abc', true],
+            ['abc', 'abc', false],
+            ['%20', ' ', false],
+            ['%cf', '%cf', true],
+            ['helios-–-the-primordial-sun', 'helios-–-the-primordial-sun', true],
+            ['helios-%E2%80%93-the-primordial-sun', 'helios-–-the-primordial-sun', false],
         ];
 
-        test.each(testQueries)(`it works with not encoded urls: '%s' (regular)`, async (query, decoded) => {
+        test.each(testQueries)(`it works with not encoded urls: '%s' (regular)`, async (query, decoded, forceEncode) => {
             const response = await requestAsBrowser({
                 url: `http://${HOSTNAME}:${port}/test-encoding/?q=${query}`,
+                forceUrlEncoding: forceEncode,
             });
             expect(response.statusCode).toBe(200);
             expect(JSON.parse(response.body).q).toBe(decoded);
         });
 
-        test.each(testQueries)(`it works with not encoded urls: '%s' (stream)`, async (query, decoded) => {
+        test.each(testQueries)(`it works with not encoded urls: '%s' (stream)`, async (query, decoded, forceEncode) => {
             const response = await requestAsBrowser({
                 url: `http://${HOSTNAME}:${port}/test-encoding/?q=${query}`,
                 stream: true,
+                forceUrlEncoding: forceEncode,
             });
 
             const chunks = [];

--- a/test/utils_request.test.js
+++ b/test/utils_request.test.js
@@ -1,7 +1,5 @@
 import express from 'express';
-import {
-    requestAsBrowser,
-} from '../build/utils_request';
+import { requestAsBrowser } from '../build/utils_request';
 import { startExpressAppPromise } from './_helper';
 
 const CONTENT = 'CONTENT';
@@ -41,6 +39,10 @@ describe('Apify.utils_request', () => {
         app.get('/invalidContentHeader', (req, res) => {
             res.setHeader('Content-Type', 'non-existent-content-type');
             res.send(CONTENT);
+        });
+
+        app.get('/test-encoding', (req, res) => {
+            res.json(req.query);
         });
 
         app.get('/invalidBody', async (req, res) => {
@@ -91,18 +93,47 @@ describe('Apify.utils_request', () => {
     });
 
     describe('Apify.requestAsBrowser', () => {
-        test(
-            'it uses mobile user-agent when mobile property is set to true ',
-            async () => {
-                const data = {
-                    url: `http://${HOSTNAME}:${port}/echo`,
-                    useMobileVersion: true,
-                };
-                const response = await requestAsBrowser(data);
-                expect(response.statusCode).toBe(200);
-                expect(response.request.options.context.headerGeneratorOptions.devices).toEqual(['mobile']);
-            },
-        );
+        test('it uses mobile user-agent when mobile property is set to true', async () => {
+            const data = {
+                url: `http://${HOSTNAME}:${port}/echo`,
+                useMobileVersion: true,
+            };
+            const response = await requestAsBrowser(data);
+            expect(response.statusCode).toBe(200);
+            expect(response.request.options.context.headerGeneratorOptions.devices).toEqual(['mobile']);
+        });
+
+        const testQueries = [
+            ['abc', 'abc'],
+            ['%20', ' '],
+            ['%cf', '%cf'],
+            ['helios-–-the-primordial-sun', 'helios-–-the-primordial-sun'],
+            ['helios-%E2%80%93-the-primordial-sun', 'helios-–-the-primordial-sun'],
+        ];
+
+        test.each(testQueries)(`it works with not encoded urls: '%s' (regular)`, async (query, decoded) => {
+            const response = await requestAsBrowser({
+                url: `http://${HOSTNAME}:${port}/test-encoding/?q=${query}`,
+            });
+            expect(response.statusCode).toBe(200);
+            expect(JSON.parse(response.body).q).toBe(decoded);
+        });
+
+        test.each(testQueries)(`it works with not encoded urls: '%s' (stream)`, async (query, decoded) => {
+            const response = await requestAsBrowser({
+                url: `http://${HOSTNAME}:${port}/test-encoding/?q=${query}`,
+                stream: true,
+            });
+
+            const chunks = [];
+            for await (const chunk of response) {
+                chunks.push(chunk);
+            }
+            const body = JSON.parse(chunks.join());
+
+            expect(response.statusCode).toBe(200);
+            expect(body.q).toBe(decoded);
+        });
 
         test('uses desktop user-agent by default ', async () => {
             const data = {


### PR DESCRIPTION
`CheerioCrawler` downloads the web pages using the `requestAsBrowser` utility function.
As opposed to the browser based crawlers that are automatically encoding the URLs, the
`requestAsBrowser` function will not do so. We either need to manually encode the URLs
via `encodeURI()` function, or set `forceUrlEncoding: true` in the `requestAsBrowserOptions`,
which will automatically encode all the URLs before accessing them.

> We can either use `forceUrlEncoding` or encode manually, but not both - it would
> result in double encoding and therefore lead to invalid URLs.

We can use the `preNavigationHooks` to adjust `requestAsBrowserOptions`:

```
preNavigationHooks: [
    (crawlingContext, requestAsBrowserOptions) => {
        requestAsBrowserOptions.forceUrlEncoding = true;
    }
]
```

Closes #679
Related #658