### PR TITLE
fix: configuration apiBaseUrl

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -39,7 +39,7 @@ import log from './utils_log';
  * `actorId` | `APIFY_ACTOR_ID` | -
  * `actorRunId` | `APIFY_ACTOR_RUN_ID` | -
  * `actorTaskId` | `APIFY_ACTOR_TASK_ID` | -
- * `apiBaseUrl` | `APIFY_API_BASE_URL` | `'https://api.apify.com/v2'`
+ * `apiBaseUrl` | `APIFY_API_BASE_URL` | `'https://api.apify.com'`
  * `containerPort` | `APIFY_CONTAINER_PORT` | `4321`
  * `containerUrl` | `APIFY_CONTAINER_URL` | `'http://localhost:4321'`
  * `inputKey` | `APIFY_INPUT_KEY` | `'INPUT'`
@@ -107,7 +107,7 @@ export class Configuration {
         defaultDatasetId: LOCAL_ENV_VARS[ENV_VARS.DEFAULT_DATASET_ID],
         defaultRequestQueueId: LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID],
         inputKey: 'INPUT',
-        apiBaseUrl: 'https://api.apify.com/',
+        apiBaseUrl: 'https://api.apify.com',
         proxyStatusUrl: 'http://proxy.apify.com',
         proxyHostname: LOCAL_ENV_VARS[ENV_VARS.PROXY_HOSTNAME],
         proxyPort: +LOCAL_ENV_VARS[ENV_VARS.PROXY_PORT],

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -107,7 +107,7 @@ export class Configuration {
         defaultDatasetId: LOCAL_ENV_VARS[ENV_VARS.DEFAULT_DATASET_ID],
         defaultRequestQueueId: LOCAL_ENV_VARS[ENV_VARS.DEFAULT_REQUEST_QUEUE_ID],
         inputKey: 'INPUT',
-        apiBaseUrl: 'https://api.apify.com/v2',
+        apiBaseUrl: 'https://api.apify.com/',
         proxyStatusUrl: 'http://proxy.apify.com',
         proxyHostname: LOCAL_ENV_VARS[ENV_VARS.PROXY_HOSTNAME],
         proxyPort: +LOCAL_ENV_VARS[ENV_VARS.PROXY_PORT],

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -266,7 +266,7 @@ export class KeyValueStore {
      * @return {string}
      */
     getPublicUrl(key) {
-        return `${this.config.get('apiBaseUrl')}/key-value-stores/${this.id}/records/${key}`;
+        return `${this.config.get('apiBaseUrl')}v2/key-value-stores/${this.id}/records/${key}`;
     }
 
     /**

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -266,7 +266,7 @@ export class KeyValueStore {
      * @return {string}
      */
     getPublicUrl(key) {
-        return `${this.config.get('apiBaseUrl')}v2/key-value-stores/${this.id}/records/${key}`;
+        return `${this.config.get('apiBaseUrl')}/v2/key-value-stores/${this.id}/records/${key}`;
     }
 
     /**


### PR DESCRIPTION
This should fix the duplicated `/v2` in the client configuration. However, the API version should be configurable in one place, not defined in the kV store string. So another option I have in mind is that the `apify-client` should handle the versions a bit better - When the version part is presented in the URL, the client will validate the version part. If the version exists, it will keep it like that. If the version is not present in the URL, the client would add the default one.