### PR TITLE
fix: hardcode public API URL in key-value store URL getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ====================
 - **BREAKING**: Require Node.js >=15.10.0 because HTTP2 support on lower Node.js versions is very buggy.
 
+1.3.3 / 2021/08/04
+====================
+- Fix public URL getter of key-value stores
+
 1.3.2 / 2021/08/02
 ====================
 - Fix `headerGeneratorOptions` not being passed to `got-scraping` in `requestAsBrowser`.

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,12 @@ export const EXIT_CODES = {
 export const ACTOR_EVENT_NAMES_EX = { ...ACTOR_EVENT_NAMES, PERSIST_STATE: 'persistState' };
 
 /**
+ * Base URL of Apify's API endpoints.
+ * @type {string}
+ */
+export const APIFY_API_BASE_URL = 'https://api.apify.com/v2';
+
+/**
  * Additional number of seconds used in CheerioCrawler and BrowserCrawler to set a reasonable
  * handleRequestTimeoutSecs for BasicCrawler that would not impare functionality (not timeout before crawlers).
  *

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -10,6 +10,7 @@ import * as ApifyClient from 'apify-client';
 // @ts-ignore
 import { ApifyStorageLocal } from '@apify/storage-local';
 import { Configuration } from '../configuration';
+import { APIFY_API_BASE_URL } from '../constants';
 /* eslint-enable no-unused-vars,import/named,import/no-duplicates,import/order */
 
 /**
@@ -266,7 +267,7 @@ export class KeyValueStore {
      * @return {string}
      */
     getPublicUrl(key) {
-        return `${this.config.get('apiBaseUrl')}/v2/key-value-stores/${this.id}/records/${key}`;
+        return `${APIFY_API_BASE_URL}/key-value-stores/${this.id}/records/${key}`;
     }
 
     /**


### PR DESCRIPTION
context:

> After I upgraded Apify SDK to latest, KeyValue store urls are now giving IP http://10.0.81.159:8010//v2/key-value-stores/ instead of https://api.apify.com/v2/key-value-stores/ which is again not working as public url. Can you please let me know if this is bug or I am doing something wrong ? store.getPublicUrl(key) is how I am composing url
I am on 1.3.1 SDK version