### PR TITLE
Disable SSL validation on MITM proxies

### DIFF
--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -510,7 +510,7 @@ export default class BrowserCrawler extends BasicCrawler {
             launchContextExtends.proxyInfo = proxyInfo;
 
             if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
-                launchContext.ignoreHTTPSErrors = true;
+                launchContext.launchOptions.ignoreHTTPSErrors = true;
             }
         }
 

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -510,6 +510,10 @@ export default class BrowserCrawler extends BasicCrawler {
             launchContextExtends.proxyInfo = proxyInfo;
 
             if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
+                /**
+                 * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
+                 * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+                 */
                 launchContext.launchOptions.ignoreHTTPSErrors = true;
             }
         }

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -510,8 +510,7 @@ export default class BrowserCrawler extends BasicCrawler {
             launchContextExtends.proxyInfo = proxyInfo;
 
             if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
-                // @szmarczak: What's the difference with launchContextExtends?
-                launchContext.ignoreHTTPSErrors = true; // Playwright
+                launchContext.ignoreHTTPSErrors = true;
             }
         }
 

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -509,6 +509,7 @@ export default class BrowserCrawler extends BasicCrawler {
             launchContext.proxyUrl = proxyInfo.url;
             launchContextExtends.proxyInfo = proxyInfo;
 
+            // Disable SSL verification for MITM proxies
             if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
                 /**
                  * @see https://playwright.dev/docs/api/class-browser/#browser-new-context

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -508,6 +508,11 @@ export default class BrowserCrawler extends BasicCrawler {
             const proxyInfo = this.proxyConfiguration.newProxyInfo(launchContextExtends.session && launchContextExtends.session.id);
             launchContext.proxyUrl = proxyInfo.url;
             launchContextExtends.proxyInfo = proxyInfo;
+
+            if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
+                // @szmarczak: What's the difference with launchContextExtends?
+                launchContext.ignoreHTTPSErrors = true; // Playwright
+            }
         }
 
         launchContext.extend(launchContextExtends);

--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -510,7 +510,7 @@ export default class BrowserCrawler extends BasicCrawler {
             launchContextExtends.proxyInfo = proxyInfo;
 
             // Disable SSL verification for MITM proxies
-            if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
+            if (this.proxyConfiguration.isManInTheMiddle) {
                 /**
                  * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
                  * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -741,7 +741,7 @@ class CheerioCrawler extends BasicCrawler {
         };
 
         // Disable SSL verification for MITM proxies
-        if (this.proxyConfiguration && this.proxyConfiguration.hasRestrictedResidentialProxy) {
+        if (this.proxyConfiguration && this.proxyConfiguration.isManInTheMiddle) {
             mandatoryRequestOptions.https = {
                 ...mandatoryRequestOptions.https,
                 rejectUnauthorized: false,

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -740,6 +740,10 @@ class CheerioCrawler extends BasicCrawler {
             },
         };
 
+        if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
+            mandatoryRequestOptions.rejectUnauthorized = false;
+        }
+
         if (/PATCH|POST|PUT/.test(request.method)) mandatoryRequestOptions.payload = request.payload;
 
         return { ...this.requestOptions, ...mandatoryRequestOptions };

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -740,7 +740,7 @@ class CheerioCrawler extends BasicCrawler {
             },
         };
 
-        if (this.proxyConfiguration.hasRestrictedResidentialProxy) {
+        if (this.proxyConfiguration && this.proxyConfiguration.hasRestrictedResidentialProxy) {
             mandatoryRequestOptions.rejectUnauthorized = false;
         }
 

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -741,7 +741,10 @@ class CheerioCrawler extends BasicCrawler {
         };
 
         if (this.proxyConfiguration && this.proxyConfiguration.hasRestrictedResidentialProxy) {
-            mandatoryRequestOptions.rejectUnauthorized = false;
+            mandatoryRequestOptions.https = {
+                ...mandatoryRequestOptions.https,
+                rejectUnauthorized: false,
+            };
         }
 
         if (/PATCH|POST|PUT/.test(request.method)) mandatoryRequestOptions.payload = request.payload;

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -740,6 +740,7 @@ class CheerioCrawler extends BasicCrawler {
             },
         };
 
+        // Disable SSL verification for MITM proxies
         if (this.proxyConfiguration && this.proxyConfiguration.hasRestrictedResidentialProxy) {
             mandatoryRequestOptions.https = {
                 ...mandatoryRequestOptions.https,

--- a/src/proxy_configuration.js
+++ b/src/proxy_configuration.js
@@ -195,6 +195,7 @@ export class ProxyConfiguration {
         this.usesApifyProxy = !this.proxyUrls && !this.newUrlFunction;
         this.log = defaultLog.child({ prefix: 'ProxyConfiguration' });
         this.config = config;
+        this.hasRestrictedResidentialProxy = false;
     }
 
     /**
@@ -348,7 +349,9 @@ export class ProxyConfiguration {
     async _checkAccess() {
         const status = await this._fetchStatus();
         if (status) {
-            const { connected, connectionError } = status;
+            const { connected, connectionError, hasRestrictedResidentialProxy } = status;
+            this.hasRestrictedResidentialProxy = hasRestrictedResidentialProxy;
+
             if (!connected) this._throwApifyProxyConnectionError(connectionError);
         } else {
             this.log.warning('Apify Proxy access check timed out. Watch out for errors with status code 407. '

--- a/src/proxy_configuration.js
+++ b/src/proxy_configuration.js
@@ -195,7 +195,7 @@ export class ProxyConfiguration {
         this.usesApifyProxy = !this.proxyUrls && !this.newUrlFunction;
         this.log = defaultLog.child({ prefix: 'ProxyConfiguration' });
         this.config = config;
-        this.hasRestrictedResidentialProxy = false;
+        this.isManInTheMiddle = false;
     }
 
     /**
@@ -349,8 +349,8 @@ export class ProxyConfiguration {
     async _checkAccess() {
         const status = await this._fetchStatus();
         if (status) {
-            const { connected, connectionError, hasRestrictedResidentialProxy } = status;
-            this.hasRestrictedResidentialProxy = hasRestrictedResidentialProxy;
+            const { connected, connectionError, isManInTheMiddle } = status;
+            this.isManInTheMiddle = isManInTheMiddle;
 
             if (!connected) this._throwApifyProxyConnectionError(connectionError);
         } else {


### PR DESCRIPTION
Not sure how do I test this. Another question: Does `ProxyConfiguration` always get set up before setting up a browser? If no, then we should fix this so this option gets applied as well.