### PR TITLE
Pin `got-scraping` to `2.1.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "content-type": "^1.0.4",
         "express": "^4.17.1",
         "fs-extra": "^10.0.0",
-        "got-scraping": "2.1.3-beta.1",
+        "got-scraping": "2.1.2",
         "htmlparser2": "^6.1.0",
         "iconv-lite": "^0.6.3",
         "jquery": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "content-type": "^1.0.4",
         "express": "^4.17.1",
         "fs-extra": "^10.0.0",
-        "got-scraping": "2.1.2",
+        "got-scraping": "2.1.3",
         "htmlparser2": "^6.1.0",
         "iconv-lite": "^0.6.3",
         "jquery": "^3.6.0",


### PR DESCRIPTION
The `2.1.3-beta` uses `hpagent` which doesn't support usual web proxies.
Some Apify proxies don't support the `CONNECT` protocol as well.
Therefore it was returning `socket hang up` errors.

Unfortunately this brings back unhandled exceptions caused by `agent-base` / `http-proxy-agent`.