### PR TITLE
chore: Use `DISABLE_OUTDATED_WARNING` from `@apify/consts` instead of defining it separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "lint:fix": "eslint ./src ./test --ext .js,.jsx --fix"
     },
     "dependencies": {
-        "@apify/consts": "^1.1.3",
+        "@apify/consts": "^1.3.0",
         "@apify/datastructures": "^1.0.1",
         "@apify/log": "^1.1.1",
         "@apify/ps-tree": "^1.1.4",

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,12 +42,6 @@ const URL_NO_COMMAS_REGEX = RegExp('https?://(www\\.)?[\\p{L}0-9][-\\p{L}0-9@:%.
  */
 const URL_WITH_COMMAS_REGEX = RegExp('https?://(www\\.)?[\\p{L}0-9][-\\p{L}0-9@:%._\\+~#=]{0,254}[\\p{L}0-9]\\.[a-z]{2,63}(:\\d{1,5})?(/[-\\p{L}0-9@:%_\\+,.~#?&//=\\(\\)]*)?', 'giu'); // eslint-disable-line
 
-/**
- * Allows turning off the warning that gets printed whenever an actor is run with an outdated SDK on the Apify Platform.
- * @type {string}
- */
-const DISABLE_OUTDATED_WARNING = 'APIFY_DISABLE_OUTDATED_WARNING';
-
 const psTreePromised = util.promisify(psTree);
 
 /**
@@ -570,7 +564,7 @@ export const snakeCaseToCamelCase = (snakeCaseStr) => {
  * @ignore
  */
 export const printOutdatedSdkWarning = () => {
-    if (process.env[DISABLE_OUTDATED_WARNING]) return;
+    if (process.env[ENV_VARS.DISABLE_OUTDATED_WARNING]) return;
     const latestApifyVersion = process.env[ENV_VARS.SDK_LATEST_VERSION];
     if (!latestApifyVersion || !semver.lt(apifyVersion, latestApifyVersion)) return;
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -705,11 +705,11 @@ describe('utils.printOutdatedSdkWarning()', () => {
         utils.printOutdatedSdkWarning();
     });
 
-    test('should do nothing when APIFY_DISABLE_OUTDATED_WARNING is set', () => {
-        process.env.APIFY_DISABLE_OUTDATED_WARNING = '1';
+    test('should do nothing when ENV_VARS.DISABLE_OUTDATED_WARNING is set', () => {
+        process.env[ENV_VARS.DISABLE_OUTDATED_WARNING] = '1';
         logMock.expects('warning').never();
         utils.printOutdatedSdkWarning();
-        delete process.env.APIFY_DISABLE_OUTDATED_WARNING;
+        delete process.env[ENV_VARS.DISABLE_OUTDATED_WARNING];
     });
 
     test('should correctly work when outdated', () => {


### PR DESCRIPTION
We recently added the env var `APIFY_DISABLE_OUTDATED_WARNING` to `@apify/consts`, let's import it from there for consistency instead of redefining it.