### PR TITLE
fix: incognito pages and user data dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "The scalable web crawling and scraping library for JavaScript/Node.js. Enables development of data extraction and web automation jobs (not only) with headless Chrome and Puppeteer.",
     "engines": {
         "node": ">=15.10.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@types/socket.io": "^2.1.13",
         "@types/tough-cookie": "^4.0.1",
         "apify-client": "^1.4.2",
-        "browser-pool": "^2.0.1-beta.0",
+        "browser-pool": "^2.0.1",
         "cheerio": "1.0.0-rc.10",
         "content-type": "^1.0.4",
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@types/socket.io": "^2.1.13",
         "@types/tough-cookie": "^4.0.1",
         "apify-client": "^1.4.2",
-        "browser-pool": "^2.0.0",
+        "browser-pool": "^2.0.1-beta.0",
         "cheerio": "1.0.0-rc.10",
         "content-type": "^1.0.4",
         "express": "^4.17.1",

--- a/src/browser_launchers/browser_launcher.js
+++ b/src/browser_launchers/browser_launcher.js
@@ -30,9 +30,10 @@ import { BrowserPlugin } from './browser_plugin'; // eslint-disable-line no-unus
  */
 export default class BrowserLauncher {
     static optionsShape = {
-        launcher: ow.object,
         proxyUrl: ow.optional.string.url,
         useChrome: ow.optional.boolean,
+        useIncognitoPages: ow.optional.boolean,
+        userDataDir: ow.optional.string,
         launchOptions: ow.optional.object,
     }
 
@@ -64,13 +65,12 @@ export default class BrowserLauncher {
     * All `BrowserLauncher` parameters are passed via an launchContext object.
     */
     constructor(launchContext) {
-        ow(launchContext, 'BrowserLauncherOptions', ow.object.exactShape(BrowserLauncher.optionsShape));
-
         const {
             launcher,
             proxyUrl,
             useChrome,
             launchOptions = {},
+            ...otherLaunchContextProps
         } = launchContext;
 
         this._validateProxyUrlProtocol(proxyUrl);
@@ -82,6 +82,7 @@ export default class BrowserLauncher {
         this.useChrome = useChrome;
         /** @type {Object<string, *>} */
         this.launchOptions = launchOptions;
+        this.otherLaunchContextProps = otherLaunchContextProps;
 
         /** @type {BrowserPlugin} */
         this.Plugin = null; // to be provided by child classes;
@@ -97,6 +98,7 @@ export default class BrowserLauncher {
             {
                 proxyUrl: this.proxyUrl,
                 launchOptions: this.createLaunchOptions(),
+                ...this.otherLaunchContextProps,
             },
         );
     }
@@ -108,10 +110,7 @@ export default class BrowserLauncher {
     async launch() {
         const plugin = this.createBrowserPlugin();
         const context = await plugin.createLaunchContext();
-
-        const browser = await plugin.launch(context);
-
-        return browser;
+        return plugin.launch(context);
     }
 
     /**

--- a/src/browser_launchers/puppeteer_launcher.js
+++ b/src/browser_launchers/puppeteer_launcher.js
@@ -1,6 +1,6 @@
 import ow from 'ow';
 import { LaunchOptions } from 'puppeteer'; // eslint-disable-line no-unused-vars,import/named
-import { PuppeteerPlugin } from 'browser-pool';
+import { PuppeteerPlugin } from '../../../browser-pool';
 import BrowserLauncher from './browser_launcher';
 import { isAtHome } from '../utils';
 import { DEFAULT_USER_AGENT } from '../constants';

--- a/src/browser_launchers/puppeteer_launcher.js
+++ b/src/browser_launchers/puppeteer_launcher.js
@@ -1,6 +1,6 @@
 import ow from 'ow';
 import { LaunchOptions } from 'puppeteer'; // eslint-disable-line no-unused-vars,import/named
-import { PuppeteerPlugin } from '../../../browser-pool';
+import { PuppeteerPlugin } from 'browser-pool';
 import BrowserLauncher from './browser_launcher';
 import { isAtHome } from '../utils';
 import { DEFAULT_USER_AGENT } from '../constants';

--- a/test/browser_launchers/playwright_launcher.test.js
+++ b/test/browser_launchers/playwright_launcher.test.js
@@ -191,7 +191,7 @@ describe('Apify.launchPlaywright()', () => {
             expect(plugin.launchOptions.executablePath).toBe(utils.getTypicalChromeExecutablePath());
         });
 
-        test('allows to be overriden', () => {
+        test('allows to be overridden', () => {
             const newPath = 'newPath';
 
             const launcher = new PlaywrightLauncher({
@@ -220,5 +220,39 @@ describe('Apify.launchPlaywright()', () => {
                 if (browser) await browser.close();
             }
         });
+    });
+
+    test('supports useIncognitoPages: true', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPlaywright({
+                useIncognitoPages: true,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.context();
+            const page2 = await browser.newPage();
+            const context2 = page2.context();
+            expect(context1).not.toBe(context2);
+        } finally {
+            if (browser) await browser.close();
+        }
+    });
+
+    test('supports useIncognitoPages: false', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPlaywright({
+                useIncognitoPages: false,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.context();
+            const page2 = await browser.newPage();
+            const context2 = page2.context();
+            expect(context1).toBe(context2);
+        } finally {
+            if (browser) await browser.close();
+        }
     });
 });

--- a/test/browser_launchers/playwright_launcher.test.js
+++ b/test/browser_launchers/playwright_launcher.test.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import proxy from 'proxy';
 import http from 'http';
 import util from 'util';
@@ -162,10 +164,10 @@ describe('Apify.launchPlaywright()', () => {
     });
 
     describe('Default browser path', () => {
-        const path = 'test';
+        const target = 'test';
 
         beforeAll(() => {
-            process.env.APIFY_DEFAULT_BROWSER_PATH = path;
+            process.env.APIFY_DEFAULT_BROWSER_PATH = target;
         });
 
         afterAll(() => {
@@ -178,7 +180,7 @@ describe('Apify.launchPlaywright()', () => {
             });
             const plugin = launcher.createBrowserPlugin();
 
-            expect(plugin.launchOptions.executablePath).toEqual(path);
+            expect(plugin.launchOptions.executablePath).toEqual(target);
         });
 
         test('does not use default when using chrome', () => {
@@ -254,5 +256,28 @@ describe('Apify.launchPlaywright()', () => {
         } finally {
             if (browser) await browser.close();
         }
+    });
+
+    test('supports userDataDir', async () => {
+        const userDataDir = path.join(__dirname, 'userDataPlaywright');
+
+        let browser;
+        try {
+            browser = await Apify.launchPuppeteer({
+                useIncognitoPages: false,
+                launchOptions: {
+                    userDataDir,
+                },
+            });
+        } finally {
+            if (browser) await browser.close();
+        }
+
+        fs.accessSync(path.join(userDataDir, 'Default'));
+
+        fs.rmSync(userDataDir, {
+            force: true,
+            recursive: true,
+        });
     });
 });

--- a/test/browser_launchers/playwright_launcher.test.js
+++ b/test/browser_launchers/playwright_launcher.test.js
@@ -265,9 +265,7 @@ describe('Apify.launchPlaywright()', () => {
         try {
             browser = await Apify.launchPuppeteer({
                 useIncognitoPages: false,
-                launchOptions: {
-                    userDataDir,
-                },
+                userDataDir,
             });
         } finally {
             if (browser) await browser.close();

--- a/test/browser_launchers/playwright_launcher.test.js
+++ b/test/browser_launchers/playwright_launcher.test.js
@@ -263,7 +263,7 @@ describe('Apify.launchPlaywright()', () => {
 
         let browser;
         try {
-            browser = await Apify.launchPuppeteer({
+            browser = await Apify.launchPlaywright({
                 useIncognitoPages: false,
                 userDataDir,
             });

--- a/test/browser_launchers/puppeteer_launcher.test.js
+++ b/test/browser_launchers/puppeteer_launcher.test.js
@@ -147,7 +147,7 @@ describe('Apify.launchPuppeteer()', () => {
         let page;
 
         // Test headless parameter
-        process.env[ENV_VARS.HEADLESS] = false;
+        process.env[ENV_VARS.HEADLESS] = 0;
 
         return Apify.launchPuppeteer({
             launchOptions: { headless: true },
@@ -242,6 +242,40 @@ describe('Apify.launchPuppeteer()', () => {
                 },
                 launchOptions: { headless: true },
             });
+        } finally {
+            if (browser) await browser.close();
+        }
+    });
+
+    test('supports useIncognitoPages: true', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPuppeteer({
+                useIncognitoPages: true,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.browserContext();
+            const page2 = await browser.newPage();
+            const context2 = page2.browserContext();
+            expect(context1).not.toBe(context2);
+        } finally {
+            if (browser) await browser.close();
+        }
+    });
+
+    test('supports useIncognitoPages: false', async () => {
+        let browser;
+        try {
+            browser = await Apify.launchPuppeteer({
+                useIncognitoPages: false,
+                launchOptions: { headless: true },
+            });
+            const page1 = await browser.newPage();
+            const context1 = page1.browserContext();
+            const page2 = await browser.newPage();
+            const context2 = page2.browserContext();
+            expect(context1).toBe(context2);
         } finally {
             if (browser) await browser.close();
         }

--- a/test/browser_launchers/puppeteer_launcher.test.js
+++ b/test/browser_launchers/puppeteer_launcher.test.js
@@ -200,7 +200,7 @@ describe('Apify.launchPuppeteer()', () => {
             });
     });
 
-    test('supports useChrome option', async () => {
+    test.skip('supports useChrome option', async () => {
         const spy = sinon.spy(utils, 'getTypicalChromeExecutablePath');
 
         let browser;
@@ -237,7 +237,12 @@ describe('Apify.launchPuppeteer()', () => {
         try {
             browser = await Apify.launchPuppeteer({
                 launcher: {
-                    launch: async () => {},
+                    launch: async () => {
+                        return {
+                            on() {},
+                            close() {},
+                        };
+                    },
                     someProps,
                 },
                 launchOptions: { headless: true },

--- a/test/browser_launchers/puppeteer_launcher.test.js
+++ b/test/browser_launchers/puppeteer_launcher.test.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import proxy from 'proxy';
 import http from 'http';
 import util from 'util';
@@ -284,5 +286,28 @@ describe('Apify.launchPuppeteer()', () => {
         } finally {
             if (browser) await browser.close();
         }
+    });
+
+    test('supports userDataDir', async () => {
+        const userDataDir = path.join(__dirname, 'userDataPuppeteer');
+
+        let browser;
+        try {
+            browser = await Apify.launchPuppeteer({
+                useIncognitoPages: false,
+                launchOptions: {
+                    userDataDir,
+                },
+            });
+        } finally {
+            if (browser) await browser.close();
+        }
+
+        fs.accessSync(path.join(userDataDir, 'Default'));
+
+        fs.rmSync(userDataDir, {
+            force: true,
+            recursive: true,
+        });
     });
 });

--- a/test/browser_launchers/puppeteer_launcher.test.js
+++ b/test/browser_launchers/puppeteer_launcher.test.js
@@ -202,7 +202,7 @@ describe('Apify.launchPuppeteer()', () => {
             });
     });
 
-    test.skip('supports useChrome option', async () => {
+    test('supports useChrome option', async () => {
         const spy = sinon.spy(utils, 'getTypicalChromeExecutablePath');
 
         let browser;

--- a/test/browser_launchers/puppeteer_launcher.test.js
+++ b/test/browser_launchers/puppeteer_launcher.test.js
@@ -297,6 +297,7 @@ describe('Apify.launchPuppeteer()', () => {
                 useIncognitoPages: false,
                 launchOptions: {
                     userDataDir,
+                    headless: true,
                 },
             });
         } finally {


### PR DESCRIPTION
Taken from #1013

- [x] `useIncognitoPages: false` works in `Apify.launchPlaywright`
- [x] `useIncognitoPages: true` works in `Apify.launchPlaywright`
- [x] `useIncognitoPages: false` works in `Apify.launchPuppeteer`
- [x]  `useIncognitoPages: true` works in `Apify.launchPuppeteer`
- [x] `userDataDir` works in `PlaywrightCrawler`
- [x] `userDataDir` works in `PuppeteerCrawler`