### PR TITLE
fix: add ts-ignore comments to imports of optional peer dependencies

### DIFF
--- a/tools/typescript_fixes.js
+++ b/tools/typescript_fixes.js
@@ -269,6 +269,11 @@ const fixTypesReferences = async () => {
                 debug('fixTypesReferences', 'fixing "node/" from file', filepath);
                 output.push(`${match[1]} "${match[2]}`);
                 changed = true;
+            } else if (match = line.match(/^([^"]+)"puppeteer"/)) {
+                debug('fixTypesReferences', 'fixing "puppeteer" from file', filepath);
+                output.push('// @ts-ignore optional peer dependency');
+                output.push(line);
+                changed = true;
             } else {
                 output.push(line);
             }


### PR DESCRIPTION
This should suppress most of the TS build errors caused by missing peer dependencies,
while still keeping things working when the dependency is installed.