### PR TITLE
feat(InfiniteScroll): use puppeteer emulating scrolls instead of window.scrollBy

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -475,7 +475,7 @@ export const infiniteScroll = async (page, options = {}) => {
 
     while (!finished) {
         await doScroll();
-        await page.waitForTimeout(50);
+        await page.waitForTimeout(100);
         if (scrollDownAndUp) {
             await page.mouse.wheel({ deltaY: -1000 });
         }

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -450,10 +450,11 @@ export const infiniteScroll = async (page, options = {}) => {
 
     const doScroll = async () => {
         /* istanbul ignore next */
-        await page.evaluate(async (scrollHeightIfZero) => {
-            const delta = document.body.scrollHeight === 0 ? scrollHeightIfZero : document.body.scrollHeight;
-            window.scrollBy(0, delta);
-        }, SCROLL_HEIGHT_IF_ZERO);
+        const bodyScrollHeight = await page.evaluate(() => document.body.scrollHeight);
+
+        const delta = bodyScrollHeight === 0 ? SCROLL_HEIGHT_IF_ZERO : bodyScrollHeight;
+
+        await page.mouse.wheel({ deltaY: delta });
     };
 
     const maybeClickButton = async () => {
@@ -468,9 +469,7 @@ export const infiniteScroll = async (page, options = {}) => {
         await doScroll();
         await page.waitForTimeout(50);
         if (scrollDownAndUp) {
-            await page.evaluate(() => {
-                window.scrollBy(0, -1000);
-            });
+            await page.mouse.wheel({ deltaY: -1000 });
         }
         if (buttonSelector) {
             await maybeClickButton();

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -429,6 +429,14 @@ export const infiniteScroll = async (page, options = {}) => {
         }
     });
 
+    // Move mouse to the center of the page, so we can scroll up-down
+    const body = await page.$('body');
+    const boundingBox = await body.boundingBox();
+    await page.mouse.move(
+        boundingBox.x + boundingBox.width / 2, // x
+        boundingBox.y + boundingBox.height / 2, // y
+    );
+
     const checkFinished = setInterval(() => {
         if (resourcesStats.oldRequested === resourcesStats.newRequested) {
             resourcesStats.matchNumber++;


### PR DESCRIPTION
This should close #1010 (but I don't know if this is the API you referred to in your issue, and it's the only other relevant example I found for scrolling). There's still a bug I need to find out why it breaks (for some reason the test case for `waitForSecs: Infinity, scrollCancelCallback` throws..)