### PR TITLE
fix: fix `YOUTUBE_REGEX_STRING` being too greedy

### DIFF
--- a/src/utils_social.js
+++ b/src/utils_social.js
@@ -194,7 +194,7 @@ const FACEBOOK_RESERVED_PATHS = 'rsrc\\.php|apps|groups|events|l\\.php|friends|i
 // eslint-disable-next-line max-len, quotes
 const FACEBOOK_REGEX_STRING = `(?<!\\w)(?:http(?:s)?:\\/\\/)?(?:www.)?(?:facebook.com|fb.com)\\/(?!(?:${FACEBOOK_RESERVED_PATHS})(?:[\\'\\"\\?\\.\\/]|$))(profile\\.php\\?id\\=[0-9]{3,20}|(?!profile\\.php)[a-z0-9\\.]{5,51})(?![a-z0-9\\.])(?:/)?`;
 // eslint-disable-next-line max-len, quotes
-const YOUTUBE_REGEX_STRING = '(?:https?:\\/\\/)?(?:youtu\\.be\\/|(?:www\\.|m\\.)?youtube\\.com\\/(?:watch|v|embed)(?:\\.php)?(?:\\?.*v=|\\/))([a-zA-Z0-9\\-_]+)';
+const YOUTUBE_REGEX_STRING = '(?:https?:\\/\\/)?(?:youtu\\.be\\/|(?:www\\.|m\\.)?youtube\\.com\\/(?:watch|v|embed)(?:\\.php)?(?:\\?[^ ]*v=|\\/))([a-zA-Z0-9\\-_]+)';
 
 /** @type RegExp */
 let LINKEDIN_REGEX;

--- a/test/utils_social.test.js
+++ b/test/utils_social.test.js
@@ -328,6 +328,14 @@ describe('utils.social', () => {
         test('works', () => {
             expect(social.parseHandlesFromHtml('')).toEqual(EMPTY_RESULT);
             expect(social.parseHandlesFromHtml('         ')).toEqual(EMPTY_RESULT);
+            const html = 'use the data in this [YouTube Video](https://www.youtube.com/watch?v=BsidLZKdYWQ).\\n\\n## Sample result\\n'
+                + 'use the data in this [YouTube Video](https://www.youtube.com/watch?v=BsidLZKd123).\\\\n\\\\n## Sample result\\\\n';
+            expect(social.parseHandlesFromHtml(html)).toMatchObject({
+                youtubes: [
+                    'https://www.youtube.com/watch?v=BsidLZKd123',
+                    'https://www.youtube.com/watch?v=BsidLZKdYWQ',
+                ],
+            });
 
             expect(social.parseHandlesFromHtml(`
                 <html>


### PR DESCRIPTION
The `.*` in the regexp caused everything in between two youtube urls to be matched as the url, resulting in issues when there were more than one youtube url. 

Closes #881