### PR TITLE
feat: support channel and user links in YouTube regex

### DIFF
--- a/src/utils_social.js
+++ b/src/utils_social.js
@@ -194,7 +194,7 @@ const FACEBOOK_RESERVED_PATHS = 'rsrc\\.php|apps|groups|events|l\\.php|friends|i
 // eslint-disable-next-line max-len, quotes
 const FACEBOOK_REGEX_STRING = `(?<!\\w)(?:http(?:s)?:\\/\\/)?(?:www.)?(?:facebook.com|fb.com)\\/(?!(?:${FACEBOOK_RESERVED_PATHS})(?:[\\'\\"\\?\\.\\/]|$))(profile\\.php\\?id\\=[0-9]{3,20}|(?!profile\\.php)[a-z0-9\\.]{5,51})(?![a-z0-9\\.])(?:/)?`;
 // eslint-disable-next-line max-len, quotes
-const YOUTUBE_REGEX_STRING = '(?:https?:\\/\\/)?(?:youtu\\.be\\/|(?:www\\.|m\\.)?youtube\\.com\\/(?:watch|v|embed)(?:\\.php)?(?:\\?[^ ]*v=|\\/))([a-zA-Z0-9\\-_]+)';
+const YOUTUBE_REGEX_STRING = '(?:https?:\\/\\/)?(?:youtu\\.be\\/|(?:www\\.|m\\.)?youtube\\.com\\/(?:watch|v|embed|user|c(?:hannel)?)(?:\\.php)?(?:\\?[^ ]*v=|\\/))([a-zA-Z0-9\\-_]+)';
 
 /** @type RegExp */
 let LINKEDIN_REGEX;
@@ -438,11 +438,14 @@ try {
     FACEBOOK_REGEX_GLOBAL = new RegExp(FACEBOOK_REGEX_STRING, 'ig');
 
     /**
-     * Regular expression to exactly match a single Youtube video URL.
+     * Regular expression to exactly match a single Youtube channel, user or video URL.
      * It has the following form: `/^...$/i` and matches URLs such as:
      * ```
      * https://www.youtube.com/watch?v=kM7YfhfkiEE
      * https://youtu.be/kM7YfhfkiEE
+     * https://www.youtube.com/c/TrapNation
+     * https://www.youtube.com/channel/UCklie6BM0fhFvzWYqQVoCTA
+     * https://www.youtube.com/user/pewdiepie
      * ```
      *
      * Example usage:
@@ -457,11 +460,14 @@ try {
     YOUTUBE_REGEX = new RegExp(`^${YOUTUBE_REGEX_STRING}$`, 'i');
 
     /**
-     * Regular expression to find multiple Youtube video URLs in a text or HTML.
+     * Regular expression to find multiple Youtube channel, user or video URLs in a text or HTML.
      * It has the following form: `/.../ig` and matches URLs such as:
      * ```
      * https://www.youtube.com/watch?v=kM7YfhfkiEE
      * https://youtu.be/kM7YfhfkiEE
+     * https://www.youtube.com/c/TrapNation
+     * https://www.youtube.com/channel/UCklie6BM0fhFvzWYqQVoCTA
+     * https://www.youtube.com/user/pewdiepie
      * ```
      *
      * Example usage:

--- a/src/utils_social.js
+++ b/src/utils_social.js
@@ -448,6 +448,8 @@ try {
      * https://www.youtube.com/user/pewdiepie
      * ```
      *
+     * Please note that this won't match URLs like https://www.youtube.com/pewdiepie that redirect to /user or /channel.
+     *
      * Example usage:
      * ```
      * if (Apify.utils.social.YOUTUBE_REGEX.test('https://www.youtube.com/watch?v=kM7YfhfkiEE')) {
@@ -469,6 +471,8 @@ try {
      * https://www.youtube.com/channel/UCklie6BM0fhFvzWYqQVoCTA
      * https://www.youtube.com/user/pewdiepie
      * ```
+     *
+     * Please note that this won't match URLs like https://www.youtube.com/pewdiepie that redirect to /user or /channel.
      *
      * Example usage:
      * ```

--- a/test/utils_social.test.js
+++ b/test/utils_social.test.js
@@ -767,6 +767,9 @@ describe('utils.social', () => {
 
             expect(social.YOUTUBE_REGEX.test('https://www.youtube.com/watch?v=kM7YfhfkiEE')).toBe(true);
             expect(social.YOUTUBE_REGEX.test('https://youtu.be/kM7YfhfkiEE')).toBe(true);
+            expect(social.YOUTUBE_REGEX.test('https://www.youtube.com/c/TrapNation')).toBe(true);
+            expect(social.YOUTUBE_REGEX.test('https://www.youtube.com/channel/UCklie6BM0fhFvzWYqQVoCTA')).toBe(true);
+            expect(social.YOUTUBE_REGEX.test('https://www.youtube.com/user/pewdiepie')).toBe(true);
             expect(`
                     -https://www.youtube.com/someusername/
                     youtube.com/jack4567
@@ -774,9 +777,15 @@ describe('utils.social', () => {
                     byoutube.com/bob
                     ayoutube.com/bob
                     _youtube.com/bob
+                    www.youtube.com/c/TrapNation
+                    https://www.youtube.com/channel/UCklie6BM0fhFvzWYqQVoCTA
+                    youtube.com/user/pewdiepie
                     `.match(social.YOUTUBE_REGEX_GLOBAL))
                 .toEqual([
                     'https://www.youtube.com/watch?v=kM7YfhfkiEE',
+                    'www.youtube.com/c/TrapNation',
+                    'https://www.youtube.com/channel/UCklie6BM0fhFvzWYqQVoCTA',
+                    'youtube.com/user/pewdiepie',
                 ]);
         });
     });


### PR DESCRIPTION
Closes #526 

One issue I found is that there seem to be channels on YouTube that work at the root level (https://www.youtube.com/jacksepticeye, https://www.youtube.com/pewdiepie are some that I found, and it seems that YouTube has redirects in place for all named channels (? citation needed)) so I don't exactly know how we should handle these. Thoughts @metalwarrior665?