### PR TITLE
refactor: use `@apify/tsconfig` with enabled `esModulesInterop`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "node": ">=15.10.0"
     },
     "main": "build/index.js",
-    "types": "types/index.d.ts",
+    "types": "build/index.d.ts",
     "keywords": [
         "apify",
         "headless",
@@ -28,16 +28,14 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/apifytech/apify-js"
+        "url": "git+https://github.com/apify/apify-js"
     },
     "bugs": {
-        "url": "https://github.com/apifytech/apify-js/issues"
+        "url": "https://github.com/apify/apify-js/issues"
     },
     "homepage": "https://sdk.apify.com/",
     "files": [
-        "build",
-        "types",
-        "types-apify"
+        "build"
     ],
     "scripts": {
         "build": "npm run clean && tsc -p tsconfig.json && node ./tools/typescript_fixes.js",
@@ -46,7 +44,7 @@
         "test": "npm run build && jest",
         "prepare": "npm run build",
         "prepublishOnly": "(test $CI || (echo \"Publishing is reserved to CI!\"; exit 1))",
-        "clean": "rimraf ./build ./types",
+        "clean": "rimraf ./build",
         "lint": "eslint ./src ./test",
         "lint:fix": "eslint ./src ./test --ext .js,.jsx --fix"
     },
@@ -87,6 +85,7 @@
     },
     "devDependencies": {
         "@apify/eslint-config": "^0.1.4",
+        "@apify/tsconfig": "^0.1.0",
         "@babel/cli": "^7.14.8",
         "@babel/core": "^7.14.8",
         "@babel/eslint-parser": "^7.14.7",
@@ -99,6 +98,7 @@
         "@types/htmlparser2": "^3.10.3",
         "@types/jest": "^27.0.1",
         "@types/node": "^15.14.2",
+        "@types/ps-tree": "^1.1.1",
         "@types/request-promise-native": "^1.0.18",
         "@types/rimraf": "^3.0.1",
         "@types/semver": "^7.3.7",

--- a/src/actor.js
+++ b/src/actor.js
@@ -1,6 +1,6 @@
 import ow from 'ow';
-import * as path from 'path';
-import * as _ from 'underscore';
+import path from 'path';
+import _ from 'underscore';
 import { ENV_VARS, INTEGER_ENV_VARS, ACT_JOB_STATUSES } from '@apify/consts';
 import log from './utils_log';
 import { EXIT_CODES } from './constants';
@@ -13,8 +13,8 @@ import {
     isAtHome,
     logSystemInfo,
     printOutdatedSdkWarning,
+    newClient,
 } from './utils';
-import * as utils from './utils';
 import { maybeStringify } from './storages/key_value_store';
 
 // eslint-disable-next-line import/named,no-unused-vars,import/first
@@ -334,7 +334,7 @@ export const call = async (actId, input, options = {}) => {
         input = maybeStringify(input, callActorOpts);
     }
 
-    const client = token ? utils.newClient({ token }) : apifyClient;
+    const client = token ? newClient({ token }) : apifyClient;
 
     let run;
     try {
@@ -458,7 +458,7 @@ export const callTask = async (taskId, input, options = {}) => {
     callTaskOpts.memory = memoryMbytes;
     callTaskOpts.timeout = timeoutSecs;
 
-    const client = token ? utils.newClient({ token }) : apifyClient;
+    const client = token ? newClient({ token }) : apifyClient;
     // Start task and wait for run to finish if waitSecs is provided
     let run;
     try {
@@ -551,7 +551,7 @@ export const metamorph = async (targetActorId, input, options = {}) => {
         input = maybeStringify(input, metamorphOpts);
     }
 
-    await utils.apifyClient.run(runId, actorId).metamorph(targetActorId, input, metamorphOpts);
+    await apifyClient.run(runId, actorId).metamorph(targetActorId, input, metamorphOpts);
 
     // Wait some time for container to be stopped.
     // NOTE: option.customAfterSleepMillis is used in tests

--- a/src/autoscaling/snapshotter.js
+++ b/src/autoscaling/snapshotter.js
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import os from 'os';
 import ow from 'ow';
 import { betterSetInterval, betterClearInterval } from '@apify/utilities';
 import { ACTOR_EVENT_NAMES, ENV_VARS } from '@apify/consts';

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,7 +1,7 @@
 import { ENV_VARS, LOCAL_ENV_VARS } from '@apify/consts';
 import { join } from 'path';
 import { ApifyStorageLocal } from '@apify/storage-local';
-import * as ApifyClient from 'apify-client';
+import ApifyClient from 'apify-client';
 import log from './utils_log';
 
 /**

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -1,7 +1,7 @@
 import { ACTOR_EVENT_NAMES } from '@apify/consts';
 import { cryptoRandomObjectId } from '@apify/utilities';
 import ow, { ArgumentError } from 'ow';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import AutoscaledPool from '../autoscaling/autoscaled_pool'; // eslint-disable-line import/no-duplicates
 import events from '../events';
 import { openSessionPool } from '../session_pool/session_pool'; // eslint-disable-line import/no-duplicates

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -1,16 +1,16 @@
 /* eslint-disable class-methods-use-this */
 import { readStreamToString, concatStreamToBuffer } from '@apify/utilities';
-import * as cheerio from 'cheerio';
-import * as contentTypeParser from 'content-type';
-import * as htmlparser from 'htmlparser2';
+import cheerio from 'cheerio';
+import contentTypeParser from 'content-type';
+import { DomHandler } from 'htmlparser2';
 import { WritableStream } from 'htmlparser2/lib/WritableStream';
-import * as iconv from 'iconv-lite';
+import iconv from 'iconv-lite';
 import ow from 'ow';
-import * as util from 'util';
+import util from 'util';
 import { TimeoutError } from 'got-scraping';
 import { BASIC_CRAWLER_TIMEOUT_BUFFER_SECS } from '../constants';
 import { addTimeoutToPromise, parseContentTypeFromResponse } from '../utils';
-import * as utilsRequest from '../utils_request'; // eslint-disable-line import/no-duplicates
+import { requestAsBrowser } from '../utils_request';
 import { BasicCrawler } from './basic_crawler'; // eslint-disable-line import/no-duplicates
 import CrawlerExtension from './crawler_extension';
 
@@ -655,7 +655,7 @@ class CheerioCrawler extends BasicCrawler {
         let responseWithStream;
 
         try {
-            responseWithStream = await utilsRequest.requestAsBrowser(opts);
+            responseWithStream = await requestAsBrowser(opts);
         } catch (e) {
             if (e instanceof TimeoutError) {
                 this._handleRequestTimeout(session);
@@ -796,7 +796,7 @@ class CheerioCrawler extends BasicCrawler {
      */
     async _parseHtmlToDom(response) {
         return new Promise((resolve, reject) => {
-            const domHandler = new htmlparser.DomHandler((err, dom) => {
+            const domHandler = new DomHandler((err, dom) => {
                 if (err) reject(err);
                 else resolve(dom);
             });

--- a/src/enqueue_links/shared.js
+++ b/src/enqueue_links/shared.js
@@ -1,5 +1,5 @@
 import { URL } from 'url';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import PseudoUrl from '../pseudo_url';
 import Request from '../request'; // eslint-disable-line import/no-duplicates
 

--- a/src/events.js
+++ b/src/events.js
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 import { ENV_VARS, ACTOR_EVENT_NAMES } from '@apify/consts';
 import { ACTOR_EVENT_NAMES_EX } from './constants';
 import defaultLog from './utils_log';

--- a/src/playwright_utils.js
+++ b/src/playwright_utils.js
@@ -1,5 +1,5 @@
 import ow from 'ow';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import { Page, Response } from 'playwright'; // eslint-disable-line no-unused-vars
 import log from './utils_log';
 import { validators } from './validators';

--- a/src/pseudo_url.js
+++ b/src/pseudo_url.js
@@ -1,5 +1,5 @@
 import ow from 'ow';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import log from './utils_log';
 import Request, { RequestOptions } from './request'; // eslint-disable-line import/named,no-unused-vars
 

--- a/src/puppeteer_request_interception.js
+++ b/src/puppeteer_request_interception.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import ow from 'ow';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import { Request as PuppeteerRequest, Page } from 'puppeteer'; // eslint-disable-line no-unused-vars
 
 // We use weak maps here so that the content gets discarted after page gets closed.

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -1,8 +1,8 @@
-import * as fs from 'fs';
+import fs from 'fs';
 import ow from 'ow';
-import * as vm from 'vm';
-import * as util from 'util';
-import * as _ from 'underscore';
+import vm from 'vm';
+import util from 'util';
+import _ from 'underscore';
 import { LruCache } from '@apify/datastructures';
 import { Page, Response, DirectNavigationOptions } from 'puppeteer'; // eslint-disable-line no-unused-vars
 import log from './utils_log';

--- a/src/request.js
+++ b/src/request.js
@@ -1,7 +1,7 @@
 import { normalizeUrl } from '@apify/utilities';
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import ow, { ArgumentError } from 'ow';
-import * as util from 'util';
+import util from 'util';
 import defaultLog from './utils_log';
 
 // new properties on the Request object breaks serialization

--- a/src/request_list.js
+++ b/src/request_list.js
@@ -1,5 +1,5 @@
 import ow, { ArgumentError } from 'ow';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import { ACTOR_EVENT_NAMES_EX } from './constants';
 import Request from './request'; // eslint-disable-line import/no-duplicates
 import events from './events';

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -1,8 +1,8 @@
 import ow from 'ow';
-import * as stream from 'stream'; // eslint-disable-line import/no-duplicates
-import * as StreamArray from 'stream-json/streamers/StreamArray';
-import * as util from 'util';
-import * as zlib from 'zlib';
+import stream from 'stream'; // eslint-disable-line import/no-duplicates
+import StreamArray from 'stream-json/streamers/StreamArray';
+import util from 'util';
+import zlib from 'zlib';
 
 // TYPE IMPORTS
 /* eslint-disable no-unused-vars,import/named,import/no-duplicates,import/order */

--- a/src/stealth/stealth.js
+++ b/src/stealth/stealth.js
@@ -1,4 +1,4 @@
-import * as _ from 'underscore';
+import _ from 'underscore';
 import { Page, Browser } from 'puppeteer'; // eslint-disable-line no-unused-vars
 import { cryptoRandomObjectId } from '@apify/utilities';
 import globalLog from '../utils_log';

--- a/src/storages/dataset.js
+++ b/src/storages/dataset.js
@@ -1,12 +1,12 @@
 import ow from 'ow';
-import * as _ from 'underscore';
+import _ from 'underscore';
 import { MAX_PAYLOAD_SIZE_BYTES } from '@apify/consts';
 import { StorageManager } from './storage_manager';
 import log from '../utils_log';
 
 /* eslint-disable no-unused-vars,import/named,import/no-duplicates,import/order */
 // @ts-ignore
-import * as ApifyClient from 'apify-client';
+import ApifyClient from 'apify-client';
 // @ts-ignore
 import { ApifyStorageLocal } from '@apify/storage-local';
 import { Configuration } from '../configuration';

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -6,7 +6,7 @@ import log from '../utils_log';
 
 /* eslint-disable no-unused-vars,import/named,import/no-duplicates,import/order */
 // @ts-ignore
-import * as ApifyClient from 'apify-client';
+import ApifyClient from 'apify-client';
 // @ts-ignore
 import { ApifyStorageLocal } from '@apify/storage-local';
 import { Configuration } from '../configuration';

--- a/src/storages/request_queue.js
+++ b/src/storages/request_queue.js
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import { ListDictionary, LruCache } from '@apify/datastructures';
 import { REQUEST_QUEUE_HEAD_MAX_LIMIT } from '@apify/consts';
 import { cryptoRandomObjectId } from '@apify/utilities';
@@ -10,7 +10,7 @@ import log from '../utils_log';
 /* eslint-disable no-unused-vars,import/named,import/no-duplicates,import/order */
 import Request, { RequestOptions } from '../request'; // eslint-disable-line import/named,no-unused-vars
 // @ts-ignore
-import * as ApifyClient from 'apify-client';
+import ApifyClient from 'apify-client';
 // @ts-ignore
 import { ApifyStorageLocal } from '@apify/storage-local';
 /* eslint-enable no-unused-vars,import/named,import/no-duplicates,import/order */

--- a/src/storages/storage_manager.js
+++ b/src/storages/storage_manager.js
@@ -2,7 +2,7 @@ import { ENV_VARS } from '@apify/consts';
 
 /* eslint-disable no-unused-vars,import/named,import/no-duplicates,import/order */
 // @ts-ignore
-import * as ApifyClient from 'apify-client';
+import ApifyClient from 'apify-client';
 // @ts-ignore
 import { ApifyStorageLocal } from '@apify/storage-local';
 import cacheContainer from '../cache_container';

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,21 +1,21 @@
-import * as psTree from '@apify/ps-tree';
+import psTree from '@apify/ps-tree';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { execSync } from 'child_process';
-import * as ApifyClient from 'apify-client';
+import ApifyClient from 'apify-client';
 import { version as apifyClientVersion } from 'apify-client/package.json';
 import { ACT_JOB_TERMINAL_STATUSES, ENV_VARS } from '@apify/consts';
-import * as cheerio from 'cheerio';
-import * as contentTypeParser from 'content-type';
-import * as fs from 'fs';
-import * as mime from 'mime-types';
-import * as os from 'os';
+import cheerio from 'cheerio';
+import contentTypeParser from 'content-type';
+import fs from 'fs';
+import mime from 'mime-types';
+import os from 'os';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import ow from 'ow';
-import * as path from 'path';
-import * as semver from 'semver';
-import * as _ from 'underscore';
+import path from 'path';
+import semver from 'semver';
+import _ from 'underscore';
 import { URL } from 'url';
-import * as util from 'util';
+import util from 'util';
 
 // TYPE IMPORTS
 /* eslint-disable no-unused-vars,import/named,import/no-duplicates,import/order */
@@ -23,7 +23,7 @@ import { IncomingMessage } from 'http';
 import { Response as PuppeteerResponse } from 'puppeteer';
 import { version as apifyVersion } from '../package.json';
 import log from './utils_log';
-import * as requestUtils from './utils_request';
+import { requestAsBrowser } from './utils_request';
 import Request, { RequestOptions } from './request';
 import { ActorRun } from './typedefs';
 
@@ -400,9 +400,6 @@ const downloadListOfUrls = async (options) => {
         urlRegExp: ow.optional.regExp,
     }));
     const { url, encoding = 'utf8', urlRegExp = URL_NO_COMMAS_REGEX } = options;
-
-    const { requestAsBrowser } = requestUtils;
-
     const { body: string } = await requestAsBrowser({ url, encoding });
     return extractUrls({ string, urlRegExp });
 };

--- a/src/utils_social.js
+++ b/src/utils_social.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-continue */
-import * as _ from 'underscore';
-import * as cheerio from 'cheerio';
+import _ from 'underscore';
+import cheerio from 'cheerio';
 import log from './utils_log';
 import { publicUtils } from './utils';
 

--- a/test/autoscaling/snapshotter.test.js
+++ b/test/autoscaling/snapshotter.test.js
@@ -4,7 +4,7 @@ import os from 'os';
 import sinon from 'sinon';
 import { ACTOR_EVENT_NAMES, ENV_VARS } from '@apify/consts';
 import log from '../../build/utils_log';
-import * as Apify from '../../build/index';
+import Apify from '../../build/index';
 import events from '../../build/events';
 import Snapshotter from '../../build/autoscaling/snapshotter';
 import * as utils from '../../build/utils';

--- a/test/crawlers/basic_crawler.test.js
+++ b/test/crawlers/basic_crawler.test.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import sinon from 'sinon';
 import { ACTOR_EVENT_NAMES } from '@apify/consts';
 import log from '../../build/utils_log';
-import * as Apify from '../../build';
+import Apify from '../../build';
 import * as keyValueStore from '../../build/storages/key_value_store';
 import { RequestQueue } from '../../build/storages/request_queue';
 import events from '../../build/events';

--- a/test/crawlers/browser_crawler.test.js
+++ b/test/crawlers/browser_crawler.test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { BrowserPool, PuppeteerPlugin } from 'browser-pool';
 import puppeteer from 'puppeteer';
 import log from '../../build/utils_log';
-import * as Apify from '../../build';
+import Apify from '../../build';
 import { STATUS_CODES_BLOCKED } from '../../build/constants';
 import LocalStorageDirEmulator from '../local_storage_dir_emulator';
 import * as utilsRequest from '../../build/utils_request';

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -7,7 +7,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import sinon from 'sinon';
 import { Readable } from 'stream';
-import * as iconv from 'iconv-lite';
+import iconv from 'iconv-lite';
 import log from '../../build/utils_log';
 import Apify from '../../build';
 import { sleep } from '../../build/utils';

--- a/test/crawlers/playwright_crawler.test.js
+++ b/test/crawlers/playwright_crawler.test.js
@@ -1,7 +1,7 @@
 import { ENV_VARS } from '@apify/consts';
 import playwright from 'playwright';
 import log from '../../build/utils_log';
-import * as Apify from '../../build';
+import Apify from '../../build';
 import LocalStorageDirEmulator from '../local_storage_dir_emulator';
 
 describe('PlaywrightCrawler', () => {

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -1,7 +1,7 @@
 import { ENV_VARS } from '@apify/consts';
 import sinon from 'sinon';
 import log from '../../build/utils_log';
-import * as Apify from '../../build';
+import Apify from '../../build';
 import LocalStorageDirEmulator from '../local_storage_dir_emulator';
 import * as utils from '../../build/utils';
 

--- a/test/enqueue_links/shared.test.js
+++ b/test/enqueue_links/shared.test.js
@@ -1,5 +1,5 @@
 import PseudoUrl from '../../build/pseudo_url';
-import * as shared from '../../build/enqueue_links/shared';
+import { constructPseudoUrlInstances, createRequestOptions, createRequests, addRequestsToQueueInBatches } from '../../build/enqueue_links/shared';
 
 describe('Enqueue links shared functions', () => {
     describe('constructPseudoUrlInstances()', () => {
@@ -10,7 +10,7 @@ describe('Enqueue links shared functions', () => {
                 'http[s?]://example.com/[.*]',
                 { purl: 'http[s?]://example.com[.*]', userData: { foo: 'bar' } },
             ];
-            const pseudoUrls = shared.constructPseudoUrlInstances(pseudoUrlSources);
+            const pseudoUrls = constructPseudoUrlInstances(pseudoUrlSources);
             expect(pseudoUrls).toHaveLength(4);
             pseudoUrls.forEach((purl) => {
                 expect(purl.matches('https://example.com/foo')).toBe(true);
@@ -22,8 +22,8 @@ describe('Enqueue links shared functions', () => {
         });
 
         test('should cache items', () => {
-            const pseudoUrls = shared.constructPseudoUrlInstances(['http[s?]://example.com/[.*]']);
-            const pseudoUrls2 = shared.constructPseudoUrlInstances(['http[s?]://example.com/[.*]']);
+            const pseudoUrls = constructPseudoUrlInstances(['http[s?]://example.com/[.*]']);
+            const pseudoUrls2 = constructPseudoUrlInstances(['http[s?]://example.com/[.*]']);
             expect(pseudoUrls[0] === pseudoUrls2[0]).toBe(true);
         });
     });
@@ -44,8 +44,8 @@ describe('Enqueue links shared functions', () => {
                 return request;
             };
 
-            const requestOptions = shared.createRequestOptions(sources);
-            const requests = shared.createRequests(requestOptions, pseudoUrls).map(transformRequestFunction).filter((r) => !!r);
+            const requestOptions = createRequestOptions(sources);
+            const requests = createRequests(requestOptions, pseudoUrls).map(transformRequestFunction).filter((r) => !!r);
 
             expect(requests).toHaveLength(2);
             requests.forEach((r) => {
@@ -67,7 +67,7 @@ describe('Enqueue links shared functions', () => {
 
             const requests = Array(5).fill(null).map((_, i) => i);
 
-            const finished = shared.addRequestsToQueueInBatches(requests, fakeRequestQueue, 2);
+            const finished = addRequestsToQueueInBatches(requests, fakeRequestQueue, 2);
 
             // With batch size 2, two requests will be dispatched synchronously before the async function
             // returns and thus the following push should place 1000 on the third place in the array.

--- a/test/storages/dataset.test.js
+++ b/test/storages/dataset.test.js
@@ -8,7 +8,7 @@ import {
     checkAndSerialize,
     chunkBySize,
 } from '../../build/storages/dataset';
-import * as Apify from '../../build';
+import Apify from '../../build';
 import { StorageManager } from '../../build/storages/storage_manager';
 
 jest.mock('../../build/storages/storage_manager');

--- a/test/storages/key_value_store.test.js
+++ b/test/storages/key_value_store.test.js
@@ -7,7 +7,7 @@ import {
     maybeStringify,
 } from '../../build/storages/key_value_store';
 import { StorageManager } from '../../build/storages/storage_manager';
-import * as Apify from '../../build';
+import Apify from '../../build';
 
 jest.mock('../../build/storages/storage_manager');
 

--- a/test/storages/request_queue.test.js
+++ b/test/storages/request_queue.test.js
@@ -1,4 +1,4 @@
-import * as Apify from '../../build';
+import Apify from '../../build';
 import { apifyClient } from '../../build/utils';
 import {
     RequestQueue,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -11,7 +11,7 @@ import Apify from '../build/index';
 import * as utils from '../build/utils';
 import log from '../build/utils_log';
 import * as requestUtils from '../build/utils_request';
-import * as htmlToTextData from './data/html_to_text_test_data';
+import htmlToTextData from './data/html_to_text_test_data';
 
 describe('utils.newClient()', () => {
     test('reads environment variables correctly', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,41 +1,18 @@
 {
+    "extends": "@apify/tsconfig",
     "compilerOptions": {
-        "target": "es2018",
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "target": "ES2020",
         "lib": [
             "DOM",
-            "DOM.Iterable",
-            "ES2015",
-            "ES2016",
-            "ES2018",
-            "ES2019.Object",
-            "ES2018.AsyncIterable",
-            "ES2020.String",
-            "ES2019.Array"
+            "ES2020",
         ],
-        "baseUrl": "./",
+        "baseUrl": ".",
         "allowJs": true,
-        "checkJs": false,
-        "noEmit": false,
-        "newLine": "lf",
-        "declaration": true,
-        "emitDeclarationOnly": false,
-        "strict": true,
-        "noImplicitAny": true,
-        "stripInternal": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "alwaysStrict": true,
-        "noStrictGenericChecks": true,
-        "strictNullChecks": true,
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": false,
-        "declarationDir": "types/",
-        "outDir": "build/"
+        "resolveJsonModule": false,
+        "noUnusedLocals": false,
+        "outDir": "build"
     },
     "include": [
-        "./types-apify/**/*.d.ts",
-        "./src/**/*.js"
+        "./src/**/*"
     ]
 }

--- a/types-apify/apify-http-request.d.ts
+++ b/types-apify/apify-http-request.d.ts
@@ -1,8 +1,0 @@
-declare module '@apify/http-request' {
-    const EXPORTED: (...args: any) => any;
-    export = EXPORTED;
-}
-
-declare module '@apify/http-request/src/errors' {
-    export const TimeoutError: Error;
-}

--- a/types-apify/ps-tree.d.ts
+++ b/types-apify/ps-tree.d.ts
@@ -1,4 +1,0 @@
-declare module '@apify/ps-tree' {
-    const EXPORTED: (pid: any, includeRoot: any, callback: any) => void;
-    export = EXPORTED;
-}


### PR DESCRIPTION
TS config has slightly changed, the main difference being we use `esModulesInterop`,
and that we no longer emit types to separate folder - they are in the same build folder
next to the source files, together with declaration source maps (`.d.ts.map` files).

Playwright types are no longer inlined, instead the same approach as with puppeteer is
taken (dynamically added `ts-ignore` comments).

As we support only node 15+, the TS `target` and `lib` options have been updated to match
this version.

Keeping the `build` folder for now, I'd switch to `dist` so we are aligned with other
repositories, but that might be actual BC, while this PR should be backwards compatible.