### PR TITLE
feat(SessionPool): allow passing `forceCloud` down to the KV store

### DIFF
--- a/src/session_pool/session_pool.js
+++ b/src/session_pool/session_pool.js
@@ -24,7 +24,7 @@ import { Configuration } from '../configuration';
  * @property {CreateSession} [createSessionFunction] - Custom function that should return `Session` instance.
  * Any error thrown from this function will terminate the process.
  * Function receives `SessionPool` instance as a parameter
- * @property {boolean} [forceCloud] If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
+ * @property {boolean} [forceCloud=false] If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
  * environment variable is set. This way it is possible to combine local and cloud storage.
  */
 

--- a/src/session_pool/session_pool.js
+++ b/src/session_pool/session_pool.js
@@ -26,6 +26,9 @@ import { Configuration } from '../configuration';
  * Function receives `SessionPool` instance as a parameter
  * @property {boolean} [forceCloud=false] If set to `true` then the function uses cloud storage usage even if the `APIFY_LOCAL_STORAGE_DIR`
  * environment variable is set. This way it is possible to combine local and cloud storage.
+ *
+ * **Note:** If you use `forceCloud`, it is recommended to also set the `persistStateKeyValueStoreId` option, as otherwise the
+ * `KeyValueStore` will be unnamed!
  */
 
 /**
@@ -171,6 +174,11 @@ export class SessionPool extends EventEmitter {
      */
     async initialize() {
         this.keyValueStore = await openKeyValueStore(this.persistStateKeyValueStoreId, { config: this.config, forceCloud: this.forceCloud });
+
+        if (this.forceCloud && !this.persistStateKeyValueStoreId) {
+            this.log.warning(`You enabled 'forceCloud' in the session pool options but you haven't specified a 'persistStateKeyValueStoreId'!`);
+            this.log.warning(`This session pool's data has been saved in the KeyValueStore with the id: ${this.keyValueStore.id}`);
+        }
 
         // in case of migration happened and SessionPool state should be restored from the keyValueStore.
         await this._maybeLoadSessionPool();


### PR DESCRIPTION
Closes #752 

Might need to change the documentation string, right now it's a 1:1 copy from KV