### PR TITLE
fix: only provide Cookie header if cookies are present

### DIFF
--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -705,11 +705,13 @@ class CheerioCrawler extends BasicCrawler {
     _applySessionCookie({ request, session }, requestAsBrowserOptions) {
         const userCookie = request.headers.Cookie ?? request.headers.cookie;
         const sessionCookie = session.getCookieString(request.url);
+        const mergedCookies = mergeCookies(request.url, [sessionCookie, userCookie]);
 
         // merge cookies from all possible sources
-        requestAsBrowserOptions.headers = {
-            Cookie: mergeCookies(request.url, [sessionCookie, userCookie]),
-        };
+        if (mergedCookies) {
+            requestAsBrowserOptions.headers ??= {};
+            requestAsBrowserOptions.headers.Cookie = mergedCookies;
+        }
     }
 
     /**


### PR DESCRIPTION
This closes #1212 