### PR TITLE
fix: Allow gotoTimeoutSecs and navigationTimeoutSecs to be 0

### DIFF
--- a/src/crawlers/browser_crawler.js
+++ b/src/crawlers/browser_crawler.js
@@ -266,8 +266,8 @@ export default class BrowserCrawler extends BasicCrawler {
         handlePageFunction: ow.function,
         gotoFunction: ow.optional.function,
 
-        gotoTimeoutSecs: ow.optional.number.greaterThan(0),
-        navigationTimeoutSecs: ow.optional.number.greaterThan(0),
+        gotoTimeoutSecs: ow.optional.number,
+        navigationTimeoutSecs: ow.optional.number,
         handlePageTimeoutSecs: ow.optional.number.greaterThan(0),
         preNavigationHooks: ow.optional.array,
         postNavigationHooks: ow.optional.array,


### PR DESCRIPTION
Setting these to zero is how puppeteer lets you disable timeout, and Apify making the number be greater than 0 disables this functionality.

https://github.com/puppeteer/puppeteer/commit/53531c9a92e06e4202883543f5ef330bd5b83afa