### PR TITLE
fix: add timeouts with retries to `runTaskFunction()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "sinon": "^12.0.0",
         "sinon-stub-promise": "^4.0.0",
         "ts-jest": "^27.0.5",
-        "typescript": "4.5.2",
+        "typescript": "4.4.4",
         "ua-parser-js": "^1.0.0",
         "why-is-node-running": "^2.2.0"
     }

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -486,8 +486,8 @@ export class BasicCrawler {
                     request = await this._fetchNextRequest();
                 }
             },
-            30e3,
-            `Fetching next request timed out after 30 seconds.`,
+            this.handleRequestTimeoutMillis,
+            `Fetching next request timed out after ${this.handleRequestTimeoutMillis * 1e3} seconds.`,
         );
 
         tryCancel();
@@ -519,8 +519,8 @@ export class BasicCrawler {
 
             await this._timeoutAndRetry(
                 () => source.markRequestHandled(request),
-                30e3,
-                `Marking request ${request.url} as handled timed out after 30 seconds.`,
+                this.handleRequestTimeoutMillis,
+                `Marking request ${request.url} as handled timed out after ${this.handleRequestTimeoutMillis * 1e3} seconds.`,
             );
             tryCancel();
             this.stats.finishJob(statisticsId);
@@ -532,8 +532,8 @@ export class BasicCrawler {
             try {
                 await this._timeoutAndRetry(
                     () => this._requestFunctionErrorHandler(err, crawlingContext, source),
-                    30e3,
-                    `Handling request failure of ${request.url} timed out after 30 seconds.`,
+                    this.handleRequestTimeoutMillis,
+                    `Handling request failure of ${request.url} timed out after ${this.handleRequestTimeoutMillis * 1e3} seconds.`,
                 );
             } catch (secondaryError) {
                 this.log.exception(secondaryError, 'runTaskFunction error handler threw an exception. '

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -2,7 +2,7 @@ import { ACTOR_EVENT_NAMES } from '@apify/consts';
 import { cryptoRandomObjectId } from '@apify/utilities';
 import ow, { ArgumentError } from 'ow';
 import _ from 'underscore';
-import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
+import { addTimeoutToPromise, TimeoutError, tryCancel } from '@apify/timeout';
 import AutoscaledPool from '../autoscaling/autoscaled_pool'; // eslint-disable-line import/no-duplicates
 import events from '../events';
 import { openSessionPool } from '../session_pool/session_pool'; // eslint-disable-line import/no-duplicates
@@ -289,7 +289,7 @@ export class BasicCrawler {
         const basicCrawlerAutoscaledPoolConfiguration = {
             minConcurrency,
             maxConcurrency,
-            runTaskFunction: this.timeoutForRunTaskFunction.bind(this),
+            runTaskFunction: this._runTaskFunction.bind(this),
             isTaskReadyFunction: async () => {
                 if (isMaxPagesExceeded()) {
                     if (shouldLogMaxPagesExceeded) {
@@ -460,27 +460,8 @@ export class BasicCrawler {
             await this.requestList.reclaimRequest(request);
             return null;
         }
-        const [nextRequest] = await Promise.all([
-            this.requestQueue.fetchNextRequest(),
-            this.requestList.markRequestHandled(request),
-        ]);
-        return nextRequest;
-    }
-
-    /**
-     * Wrapper around _runTaskFunction to set a timeout on the entire function.
-     * Temporary solution to see whether this causes the 0 concurrency bug.
-     * @ignore
-     * @internal
-     * @private
-     */
-    async timeoutForRunTaskFunction() {
-        const timeout = 600e3; // 10 min last resort timeout for stuck runs
-        await addTimeoutToPromise(
-            () => this._runTaskFunction(),
-            timeout,
-            `_runTaskFunction timed out after ${(timeout) / 1000} seconds.`,
-        );
+        await this.requestList.markRequestHandled(request);
+        return this.requestQueue.fetchNextRequest();
     }
 
     /**
@@ -497,11 +478,17 @@ export class BasicCrawler {
         let request;
         let session;
 
-        if (this.useSessionPool) {
-            [request, session] = await Promise.all([this._fetchNextRequest(), this.sessionPool.getSession()]);
-        } else {
-            request = await this._fetchNextRequest();
-        }
+        await this._timeoutAndRetry(
+            async () => {
+                if (this.useSessionPool) {
+                    [request, session] = await Promise.all([this._fetchNextRequest(), this.sessionPool.getSession()]);
+                } else {
+                    request = await this._fetchNextRequest();
+                }
+            },
+            30e3,
+            `Fetching next request timed out after 30 seconds.`,
+        );
 
         tryCancel();
 
@@ -529,7 +516,12 @@ export class BasicCrawler {
                 `handleRequestFunction timed out after ${this.handleRequestTimeoutMillis / 1000} seconds.`,
             );
             tryCancel();
-            await source.markRequestHandled(request);
+
+            await this._timeoutAndRetry(
+                () => source.markRequestHandled(request),
+                30e3,
+                `Marking request ${request.url} as handled timed out after 30 seconds.`,
+            );
             tryCancel();
             this.stats.finishJob(statisticsId);
             this.handledRequestsCount++;
@@ -538,7 +530,11 @@ export class BasicCrawler {
             if (session) session.markGood();
         } catch (err) {
             try {
-                await this._requestFunctionErrorHandler(err, crawlingContext, source);
+                await this._timeoutAndRetry(
+                    () => this._requestFunctionErrorHandler(err, crawlingContext, source),
+                    30e3,
+                    `Handling request failure of ${request.url} timed out after 30 seconds.`,
+                );
             } catch (secondaryError) {
                 this.log.exception(secondaryError, 'runTaskFunction error handler threw an exception. '
                     + 'This places the crawler and its underlying storages into an unknown state and crawling will be terminated. '
@@ -552,6 +548,27 @@ export class BasicCrawler {
         }
 
         tryCancel();
+    }
+
+    /**
+     * Run async callback with given timeout and retry.
+     * @ignore
+     */
+    async _timeoutAndRetry(handler, timeout, error, maxRetries = 3, retried = 1) {
+        try {
+            await addTimeoutToPromise(
+                handler,
+                timeout,
+                error,
+            );
+        } catch (e) {
+            if (e instanceof TimeoutError && retried <= maxRetries) {
+                this.log.warning(`${e.message} (retrying ${retried}/${maxRetries})`);
+                return this._timeoutAndRetry(handler, timeout, error, maxRetries, retried + 1);
+            }
+
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
This adds 30s timeouts with 3 retries to the async places inside
`runTaskFunction` that might be causing the zero concurrency bug.

We now get a warning every time such place timeouts and a hard
failure after 3 retries.

Related: #997