### PR TITLE
fix: revert to puppeteer 10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-2.2.1 / 2021/12/20
+2.2.1 / 2022/01/xx
 ====================
-- fix: ignore requests that are no longer in progress
+- fix: ignore requests that are no longer in progress (#1258)
+- fix: do not use `tryCancel()` from inside sync callback (#1265)
+- fix: revert to puppeteer 10.x
 
 2.2.0 / 2021/12/17
 ====================

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "playwright": "^1.11.0",
-        "puppeteer": "^9.0.0||^10.0.0||^11.0.0"
+        "puppeteer": "^9.0.0||^10.0.0"
     },
     "peerDependenciesMeta": {
         "playwright": {
@@ -122,7 +122,7 @@
         "portastic": "^1.0.1",
         "proxy": "^1.0.2",
         "proxy-chain": "^2.0.1-beta.0",
-        "puppeteer": "11.0.0",
+        "puppeteer": "10.4.0",
         "sinon": "^12.0.0",
         "sinon-stub-promise": "^4.0.0",
         "ts-jest": "^27.0.5",


### PR DESCRIPTION
v11 contains a bug that is resolved in v12, but we can't upgrade to v12 due to chrome 97 not being stable yet

Closes #1275