### PR TITLE
fix: wait when `body` is not available in `infiniteScroll()` from Puppeteer utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: ignore requests that are no longer in progress (#1258)
 - fix: do not use `tryCancel()` from inside sync callback (#1265)
 - fix: revert to puppeteer 10.x
+- fix: wait when `body` is not available in `infiniteScroll()` from Puppeteer utils
 
 2.2.0 / 2021/12/17
 ====================

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -430,7 +430,19 @@ export const infiniteScroll = async (page, options = {}) => {
     });
 
     // Move mouse to the center of the page, so we can scroll up-down
-    const body = await page.$('body');
+    let body = await page.$('body');
+    let retry = 0;
+
+    while (!body && retry < 10) {
+        await page.waitForTimeout(100);
+        body = await page.$('body');
+        retry++;
+    }
+
+    if (!body) {
+        return;
+    }
+
     const boundingBox = await body.boundingBox();
     await page.mouse.move(
         boundingBox.x + boundingBox.width / 2, // x


### PR DESCRIPTION
Should address following issue:

![image](https://user-images.githubusercontent.com/615580/147941271-ce7d38e8-235d-4db4-9bc2-894a49e7a14a.png)
