### PR TITLE
fix: expose logger classes on the `utils.log` instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fix: do not use `tryCancel()` from inside sync callback (#1265)
 - fix: revert to puppeteer 10.x
 - fix: wait when `body` is not available in `infiniteScroll()` from Puppeteer utils
+- fix: expose logger classes on the `utils.log` instance
 
 2.2.0 / 2021/12/17
 ====================

--- a/src/utils_log.js
+++ b/src/utils_log.js
@@ -192,5 +192,8 @@
 // variable can't be the same from the namespace above
 import log, { Log, LoggerOptions, LogLevel, Logger, LoggerJson, LoggerText } from '@apify/log';
 
+// workaround for 2.x, this should ideally not be backported to 3.0 (the test should be there tho)
+Object.assign(log, { Log, LogLevel, Logger, LoggerJson, LoggerText });
+
 export { Log, LoggerOptions, LogLevel, Logger, LoggerJson, LoggerText };
 export default log;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -8,6 +8,7 @@ import cheerio from 'cheerio';
 import semver from 'semver';
 import { ENV_VARS } from '@apify/consts';
 import { addTimeoutToPromise } from '@apify/timeout';
+import { Log, LoggerText } from '@apify/log';
 import Apify from '../build/index';
 import * as utils from '../build/utils';
 import log from '../build/utils_log';
@@ -32,6 +33,13 @@ describe('utils.newClient()', () => {
 
         expect(client.token).toBe('token');
         expect(client.baseUrl).toBe('https://api.apify.com/v2');
+    });
+});
+
+describe('log export exposes custom loggers', () => {
+    test('works with log.LoggerText (#1238)', () => {
+        expect(Apify.utils.log).toBeInstanceOf(Log);
+        expect(Apify.utils.log.LoggerText).toBe(LoggerText);
     });
 });
 


### PR DESCRIPTION
Closes #1238