### PR TITLE
fix: ensure `request.headers` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-2.2.1 / 2022/01/03
+2.2.2 / 2022/01/xx
+====================
+- fix: ensure `request.headers` is set
+
+- 2.2.1 / 2022/01/03
 ====================
 - fix: ignore requests that are no longer in progress (#1258)
 - fix: do not use `tryCancel()` from inside sync callback (#1265)

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -663,6 +663,7 @@ class CheerioCrawler extends BasicCrawler {
         const cookieDiff = diffCookies(request.url, cookieSnapshot, request.headers.Cookie ?? request.headers.cookie);
 
         if (cookieDiff.length > 0) {
+            requestAsBrowserOptions.headers ??= {};
             requestAsBrowserOptions.headers.Cookie = mergeCookies(request.url, [
                 requestAsBrowserOptions.headers.Cookie,
                 cookieDiff,


### PR DESCRIPTION
When changing the headers in cheerio crawler, first request may have failed as
headers object was not set. Now it will be always there before we try to access it.