### PR TITLE
fix: cookies setting in preNavigationHooks

### DIFF
--- a/src/crawlers/crawler_utils.js
+++ b/src/crawlers/crawler_utils.js
@@ -46,7 +46,7 @@ export function mergeCookies(url, sourceCookies) {
 
     // ignore empty cookies
     for (const sourceCookieString of sourceCookies.filter((c) => c)) {
-        const cookies = sourceCookieString.split(/ *; */); // ignore extra spaces
+        const cookies = sourceCookieString.split(/ *; */).filter((c) => c); // ignore extra spaces
 
         for (const cookieString of cookies) {
             const cookie = Cookie.parse(cookieString);


### PR DESCRIPTION
This issue https://github.com/apify/apify-js/issues/1266 is kinda solved in the latest beta, but while testing I stuck upon an edge case when you try to set only one cookie (like mentioned in the issue), which leads to `cookies` array here having an actual cookie and a second item, which is gonna be an empty string, which is leading to:
```
TypeError: Cannot read properties of undefined (reading 'key')
      at /Users/AndreyBykov/Documents/Apify/Playground/playground/node_modules/apify/build/crawlers/crawler_utils.js:52:31
      at Array.find (<anonymous>)
      at mergeCookies (/Users/AndreyBykov/Documents/Apify/Playground/playground/node_modules/apify/build/crawlers/crawler_utils.js:51:62)
      at CheerioCrawler._mergeRequestCookieDiff (/Users/AndreyBykov/Documents/Apify/Playground/playground/node_modules/apify/build/crawlers/cheerio_crawler.js:570:87)
      at CheerioCrawler._handleNavigation (/Users/AndreyBykov/Documents/Apify/Playground/playground/node_modules/apify/build/crawlers/cheerio_crawler.js:540:14)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async CheerioCrawler._handleRequestFunction (/Users/AndreyBykov/Documents/Apify/Playground/playground/node_modules/apify/build/crawlers/cheerio_crawler.js:475:9)
      at async wrap (/Users/AndreyBykov/Documents/Apify/Playground/playground/node_modules/@apify/timeout/index.js:73:27)
```

Closes #1266 