### PR TITLE
fix: improve guessing of chrome executable path on windows

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -355,9 +355,7 @@ export const getFirstKey = (dict) => {
 export const getTypicalChromeExecutablePath = () => {
     switch (os.platform()) {
         case 'darwin': return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-        case 'win32': return '%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe'.replace(
-            /%([^%]+)%/g, (__, n) => process.env[n]
-        );
+        case 'win32': return `${process.env.ProgramFiles}\\Google\\Chrome\\Application\\chrome.exe`;
         default: return '/usr/bin/google-chrome';
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -355,7 +355,9 @@ export const getFirstKey = (dict) => {
 export const getTypicalChromeExecutablePath = () => {
     switch (os.platform()) {
         case 'darwin': return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-        case 'win32': return 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+        case 'win32': return '%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe'.replace(
+            /%([^%]+)%/g, (__, n) => process.env[n]
+        );
         default: return '/usr/bin/google-chrome';
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -353,9 +353,29 @@ export const getFirstKey = (dict) => {
  * @ignore
  */
 export const getTypicalChromeExecutablePath = () => {
+    /**
+     * Return path of Chrome executable by its OS environment variable to deal with non-english language OS.
+     * Taking also in account the old [chrome 380177 issue](https://bugs.chromium.org/p/chromium/issues/detail?id=380177).
+     *
+     * @returns {string}
+     * @ignore
+     */
+    const getWin32Path = () => {
+        let chromeExecutablePath = 'C:\\%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe';
+        const path00 = `${process.env.ProgramFiles}\\Google\\Chrome\\Application\\chrome.exe`;
+        const path86 = `${process.env['ProgramFiles(x86)']}\\Google\\Chrome\\Application\\chrome.exe`;
+
+        if (fs.existsSync(path00)) {
+            chromeExecutablePath = path00;
+        } else if (fs.existsSync(path86)) {
+            chromeExecutablePath = path86;
+        }
+        return chromeExecutablePath;
+    };
+
     switch (os.platform()) {
         case 'darwin': return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-        case 'win32': return `${process.env.ProgramFiles}\\Google\\Chrome\\Application\\chrome.exe`;
+        case 'win32': return getWin32Path();
         default: return '/usr/bin/google-chrome';
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -361,7 +361,7 @@ export const getTypicalChromeExecutablePath = () => {
      * @ignore
      */
     const getWin32Path = () => {
-        let chromeExecutablePath = 'C:\\%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe';
+        let chromeExecutablePath = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
         const path00 = `${process.env.ProgramFiles}\\Google\\Chrome\\Application\\chrome.exe`;
         const path86 = `${process.env['ProgramFiles(x86)']}\\Google\\Chrome\\Application\\chrome.exe`;
 


### PR DESCRIPTION
Reupload: Corrected conventions on naming conventions

A PR for the case where the user windows OS is in a different language and the 'Typical Chrome Executable Path' is on a 'non-English-standard' ProgramFiles folder.
In windows, it can be gotten by the environment variable ProgramFiles(x86).