### PR TITLE
feat: add multiple click

### DIFF
--- a/src/enqueue_links/click_elements.js
+++ b/src/enqueue_links/click_elements.js
@@ -143,7 +143,7 @@ export async function enqueueLinksByClickingElements(options) {
         transformRequestFunction,
         waitForPageIdleSecs = 1,
         maxWaitForPageIdleSecs = 5,
-        clickOptions
+        clickOptions,
     } = options;
 
     const waitForPageIdleMillis = waitForPageIdleSecs * 1000;
@@ -155,7 +155,7 @@ export async function enqueueLinksByClickingElements(options) {
         selector,
         waitForPageIdleMillis,
         maxWaitForPageIdleMillis,
-        clickOptions
+        clickOptions,
     });
     let requestOptions = createRequestOptions(interceptedRequests);
     if (transformRequestFunction) {
@@ -187,7 +187,7 @@ export async function clickElementsAndInterceptNavigationRequests(options) {
         selector,
         waitForPageIdleMillis,
         maxWaitForPageIdleMillis,
-        clickOptions
+        clickOptions,
     } = options;
 
     const uniqueRequests = new Set();
@@ -336,7 +336,7 @@ async function preventHistoryNavigation(page) {
  * for large element sets, this will take considerable amount of time.
  *
  * @param {Page} page
- * @param {string} selector * 
+ * @param {string} selector
  * @param {object} [clickOptions]
  * @param {number} [clickOptions.clickCount]
  * @param {number} [clickOptions.delay]

--- a/src/enqueue_links/click_elements.js
+++ b/src/enqueue_links/click_elements.js
@@ -74,6 +74,12 @@ const STARTING_Z_INDEX = 2147400000;
  *
  *   If `pseudoUrls` is an empty array, `null` or `undefined`, then the function
  *   enqueues all links found on the page.
+ * @param {object} [options.clickOptions]
+ *   click options for use in Puppeteer's click handler
+ * @param {number} [options.clickOptions.clickCount]
+ *   Number of clicks to be executed. Defaults to 1
+ * @param {number} [options.clickOptions.delay]
+ *   Time to wait between mousedown and mouseup in milliseconds. Defaults to 0
  * @param {RequestTransform} [options.transformRequestFunction]
  *   Just before a new {@link Request} is constructed and enqueued to the {@link RequestQueue}, this function can be used
  *   to remove it or modify its contents such as `userData`, `payload` or, most importantly `uniqueKey`. This is useful
@@ -121,6 +127,7 @@ export async function enqueueLinksByClickingElements(options) {
     ow(options, ow.object.exactShape({
         page: ow.object.hasKeys('goto', 'evaluate'),
         requestQueue: ow.object.hasKeys('fetchNextRequest', 'addRequest'),
+        clickOptions: ow.optional.object.hasKeys('clickCount', 'delay'),
         selector: ow.string,
         pseudoUrls: ow.optional.array.ofType(ow.any(ow.string, ow.regExp, ow.object.hasKeys('purl'))),
         transformRequestFunction: ow.optional.function,
@@ -136,6 +143,7 @@ export async function enqueueLinksByClickingElements(options) {
         transformRequestFunction,
         waitForPageIdleSecs = 1,
         maxWaitForPageIdleSecs = 5,
+        clickOptions
     } = options;
 
     const waitForPageIdleMillis = waitForPageIdleSecs * 1000;
@@ -147,6 +155,7 @@ export async function enqueueLinksByClickingElements(options) {
         selector,
         waitForPageIdleMillis,
         maxWaitForPageIdleMillis,
+        clickOptions
     });
     let requestOptions = createRequestOptions(interceptedRequests);
     if (transformRequestFunction) {
@@ -166,6 +175,9 @@ export async function enqueueLinksByClickingElements(options) {
  * @param {string} options.selector
  * @param {number} [options.waitForPageIdleMillis]
  * @param {number} [options.maxWaitForPageIdleMillis]
+ * @param {object} [clickOptions]
+ * @param {number} [clickOptions.clickCount]
+ * @param {number} [clickOptions.delay]
  * @return {Promise<Array<*>>}
  * @ignore
  */
@@ -175,6 +187,7 @@ export async function clickElementsAndInterceptNavigationRequests(options) {
         selector,
         waitForPageIdleMillis,
         maxWaitForPageIdleMillis,
+        clickOptions
     } = options;
 
     const uniqueRequests = new Set();
@@ -190,7 +203,7 @@ export async function clickElementsAndInterceptNavigationRequests(options) {
 
     await preventHistoryNavigation(page);
 
-    await clickElements(page, selector);
+    await clickElements(page, selector, clickOptions);
     await waitForPageIdle({ page, waitForPageIdleMillis, maxWaitForPageIdleMillis });
 
     await restoreHistoryNavigationAndSaveCapturedUrls(page, uniqueRequests);
@@ -323,11 +336,14 @@ async function preventHistoryNavigation(page) {
  * for large element sets, this will take considerable amount of time.
  *
  * @param {Page} page
- * @param {string} selector
+ * @param {string} selector * 
+ * @param {object} [clickOptions]
+ * @param {number} [clickOptions.clickCount]
+ * @param {number} [clickOptions.delay]
  * @return {Promise<void>}
  * @ignore
  */
-export async function clickElements(page, selector) {
+export async function clickElements(page, selector, clickOptions) {
     const elementHandles = await page.$$(selector);
     log.debug(`enqueueLinksByClickingElements: There are ${elementHandles.length} elements to click.`);
     let clickedElementsCount = 0;
@@ -336,7 +352,7 @@ export async function clickElements(page, selector) {
     for (const handle of elementHandles) {
         try {
             await page.evaluate(updateElementCssToEnableMouseClick, handle, zIndex++);
-            await handle.click();
+            await handle.click(clickOptions);
             clickedElementsCount++;
         } catch (err) {
             if (shouldLogWarning && err.stack.includes('is detached from document')) {

--- a/test/enqueue_links/click_elements.test.js
+++ b/test/enqueue_links/click_elements.test.js
@@ -222,6 +222,32 @@ describe('enqueueLinksByClickingElements()', () => {
         });
     });
 
+    describe('select line with triple clickElements()', () => {
+        test('should select the text by triple clicking', async () => {
+            const html = `
+<html>
+    <body>
+        <textarea></textarea>
+    </body>
+</html>
+        `;
+            await page.setContent(html);
+            await page.focus('textarea');
+            const text = "This is the text that we are going to try to select. Let's see how it goes.";
+            await page.keyboard.type(text);
+            await clickElements(page, 'textarea', { clickCount: 3, delay: 100 });
+            expect(
+                await page.evaluate(() => {
+                    const textarea = document.querySelector('textarea');
+                    return textarea.value.substring(
+                        textarea.selectionStart,
+                        textarea.selectionEnd,
+                    );
+                }),
+            ).toBe(text);
+        });
+    });
+
     describe('clickElementsAndInterceptNavigationRequests()', () => {
         function getOpts(overrides = {}) {
             return {


### PR DESCRIPTION
Here is the feature i was trying to introduce as mentioned in #1294.
It adds the option for multiple clicks.

Use cases:

 - A normal use would be for example to handle [dblclick events](https://developer.mozilla.org/en-US/docs/Web/API/Element/dblclick_event). They have been introduced for many years and have high compatibility with most browsers.

 - In my personal use case, i was considering supporting some existing "application like" web interactions for an utility app aiming at organizing and managing some private files in the cloud.

I only added tests for dblclick events (coping the existing ones). I think they should apply for most of the situations. But one probably should consider adding some kind of "limited" tests for more dynamic click counts or simply limiting the feature to a maximum of 2 clicks (more limited but also more realistic?).
