### PR TITLE
fix: build before linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prepare": "npm run build",
         "prepublishOnly": "(test $CI || (echo \"Publishing is reserved to CI!\"; exit 1))",
         "clean": "rimraf ./build",
-        "lint": "eslint ./src ./test",
+        "lint": "npm run build && eslint ./src ./test",
         "lint:fix": "eslint ./src ./test --ext .js,.jsx --fix"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "prepublishOnly": "(test $CI || (echo \"Publishing is reserved to CI!\"; exit 1))",
         "clean": "rimraf ./build",
         "lint": "npm run build && eslint ./src ./test",
-        "lint:fix": "eslint ./src ./test --ext .js,.jsx --fix"
+        "lint:fix": "npm run build && eslint ./src ./test --ext .js,.jsx --fix"
     },
     "dependencies": {
         "@apify/consts": "^1.3.0",


### PR DESCRIPTION
Here is another "quick" fix patch.

Adds a build phase before the lint script.

Reason: 
Several tests depend on having a build project like for example [actor.test.js#L9](https://github.com/audiBookning/apify-js/blob/a8b1fbcc3f6edaddf8d73aa2146f17c0bd1c40b6/test/actor.test.js#L9).
Avoids error like: `error  Missing file extension for "../build/errors"  import/extensions`

