### PR TITLE
feat: bump puppeteer support to up to v13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "portastic": "^1.0.1",
         "proxy": "^1.0.2",
         "proxy-chain": "^2.0.1-beta.0",
-        "puppeteer": "13.4.0",
+        "puppeteer": "13.5.1",
         "sinon": "^12.0.0",
         "sinon-stub-promise": "^4.0.0",
         "ts-jest": "^27.0.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "playwright": "^1.11.0",
-        "puppeteer": "^9.0.0||^10.0.0"
+        "puppeteer": ">= 9.x <= 13.x"
     },
     "peerDependenciesMeta": {
         "playwright": {
@@ -122,7 +122,7 @@
         "portastic": "^1.0.1",
         "proxy": "^1.0.2",
         "proxy-chain": "^2.0.1-beta.0",
-        "puppeteer": "10.4.0",
+        "puppeteer": "13.4.0",
         "sinon": "^12.0.0",
         "sinon-stub-promise": "^4.0.0",
         "ts-jest": "^27.0.5",


### PR DESCRIPTION
For now, this is blocked while I await an answer for https://github.com/puppeteer/puppeteer/issues/8059

All tests seem to pass fine with v13 (except the userDataDir one [EDIT from the future: see issue above, which was fixed and published]), and the docker image does build (locally you'll need to change all npm installs to include --force to ignore the peer dep errors if you want to try them)