### PR TITLE
fix: reset `RequestQueue` state after 5 minutes of inactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+2.3.0 / 2022/04/07
+====================
+- feat: accept more social media patterns (#1286)
+- feat: add multiple click support to `enqueueLinksByClickingElements` (#1295)
+- feat: instance-scoped "global" configuration (#1315)
+- feat: requestList accepts proxyConfiguration for requestsFromUrls (#1317)
+- feat: update `playwright` to v1.20.2
+- feat: update `puppeteer` to v13.5.2
+- feat: stealth deprecation (#1314)
+- fix: use correct apify-client instance for snapshotting (#1308)
+- fix: automatically reset `RequestQueue` state after 5 minutes of inactivity, closes #997
+- fix: improve guessing of chrome executable path on windows (#1294)
+- fix: prune CPU snapshots locally (#1313)
+- fix: improve browser launcher types (#1318)
+
+### 0 concurrency mitigation
+
+This release should resolve the 0 concurrency bug by automatically resetting the
+internal `RequestQueue` state after 5 minutes of inactivity.
+
+We now track last activity done on a `RequestQueue` instance:
+- added new request
+- started processing a request (added to `inProgress` cache)
+- marked request as handled
+- reclaimed request
+
+If we don't detect one of those actions in last 5 minutes, and we have some
+requests in the `inProgress` cache, we try to reset the state. We can override
+this limit via `APIFY_INTERNAL_TIMEOUT` env var.
+
+This should finally resolve the 0 concurrency bug, as it was always about
+stuck requests in the `inProgress` cache.
+
 2.2.2 / 2022/02/xx
 ====================
 - fix: ensure `request.headers` is set

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apify",
-    "version": "2.2.3",
+    "version": "2.3.0",
     "description": "The scalable web crawling and scraping library for JavaScript/Node.js. Enables development of data extraction and web automation jobs (not only) with headless Chrome and Puppeteer.",
     "engines": {
         "node": ">=15.10.0"

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -262,7 +262,13 @@ export class BasicCrawler {
         this.userProvidedHandler = handleRequestFunction;
         this.failedContextHandler = handleFailedRequestFunction;
         this.handleRequestTimeoutMillis = handleRequestTimeoutSecs * 1000;
-        this.internalTimeoutMillis = Math.max(this.handleRequestTimeoutMillis, 300e3); // allow at least 5min for internal timeouts
+        const tryEnv = (val) => (val == null ? val : +val);
+        // allow at least 5min for internal timeouts
+        this.internalTimeoutMillis = tryEnv(process.env.APIFY_INTERNAL_TIMEOUT) ?? Math.max(this.handleRequestTimeoutMillis, 300e3);
+        // override the default internal timeout of request queue to respect `handleRequestTimeoutMillis`
+        if (this.requestQueue) {
+            this.requestQueue.internalTimeoutMillis = this.internalTimeoutMillis;
+        }
         this.handleFailedRequestFunction = handleFailedRequestFunction;
         this.maxRequestRetries = maxRequestRetries;
         this.handledRequestsCount = 0;

--- a/test/request_queue_reset.test-e2e.js
+++ b/test/request_queue_reset.test-e2e.js
@@ -1,0 +1,26 @@
+// $ npm run build && node test/request_queue_reset.test-e2e.js
+
+const Apify = require('../build');
+
+// RequestQueue auto-reset when stuck with requests in progress
+Apify.main(async () => {
+    process.env.APIFY_INTERNAL_TIMEOUT = '30000'; // 30s
+    Apify.utils.log.setLevel(Apify.utils.log.LEVELS.DEBUG);
+    await Apify.utils.purgeLocalStorage();
+    const requestQueue = await Apify.openRequestQueue();
+    await requestQueue.addRequest({ url: 'https://example.com/?q=1' });
+    await requestQueue.addRequest({ url: 'https://example.com/?q=2' });
+    const r3 = await requestQueue.addRequest({ url: 'https://example.com/?q=3' });
+
+    // trigger 0 concurrency by marking one of the requests as already in progress
+    requestQueue.inProgress.add(r3.requestId);
+
+    const crawler = new Apify.CheerioCrawler({
+        requestQueue,
+        handlePageFunction: async (ctx) => {
+            Apify.utils.log.info(ctx.request.id);
+        },
+    });
+
+    await crawler.run();
+});


### PR DESCRIPTION
We now track last activity done on a `RequestQueue` instance:
- added new request
- started processing a request (added to `inProgress` cache)
- marked request as handled
- reclaimed request

If we don't detect one of those actions in last 5 minutes, and we have some requests in the `inProgress` cache, we try to reset the state. We can override this limit via `APIFY_INTERNAL_TIMEOUT` env var. If request handler timeout value is higher, we use that instead. This internal timeout is also used when executing the user-provided request handler, so we know there needs to be some activity in this internal (the handler either finished or timeouted).

This should finally resolve the 0 concurrency bug, as it was always about stuck requests in the `inProgress` cache.

Closes #997