### PR TITLE
feat: allow passing a stream to `KeyValueStore.setRecord`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "got-scraping": "^3.2.7",
         "htmlparser2": "^7.0.0",
         "iconv-lite": "^0.6.3",
-        "is-stream": "^2.0.1",
         "jquery": "^3.6.0",
         "mime-types": "^2.1.31",
         "ow": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "got-scraping": "^3.2.7",
         "htmlparser2": "^7.0.0",
         "iconv-lite": "^0.6.3",
+        "is-stream": "^2.0.1",
         "jquery": "^3.6.0",
         "mime-types": "^2.1.31",
         "ow": "^0.28.0",

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -11,7 +11,6 @@ import { ApifyClient } from 'apify-client';
 import { ApifyStorageLocal } from '@apify/storage-local';
 import { Configuration } from '../configuration';
 import { APIFY_API_BASE_URL } from '../constants';
-import isStream from 'is-stream';
 /* eslint-enable no-unused-vars,import/named,import/no-duplicates,import/order */
 
 /**
@@ -224,7 +223,7 @@ export class KeyValueStore {
             validator: ow.isValid(k, ow.string.matches(KEY_VALUE_STORE_KEY_REGEX)),
             message: 'The "key" argument must be at most 256 characters long and only contain the following characters: a-zA-Z0-9!-_.\'()',
         })));
-        if (options.contentType && !(ow.isValid(value, ow.any(ow.string, ow.buffer)) || isStream(value))) {
+        if (options.contentType && !ow.isValid(value, ow.any(ow.string, ow.buffer, ow.object))) {
             throw new ArgumentError('The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.', this.setValue);
         }
         ow(options, ow.object.exactShape({

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -223,7 +223,7 @@ export class KeyValueStore {
             validator: ow.isValid(k, ow.string.matches(KEY_VALUE_STORE_KEY_REGEX)),
             message: 'The "key" argument must be at most 256 characters long and only contain the following characters: a-zA-Z0-9!-_.\'()',
         })));
-        if (options.contentType && !ow.isValid(value, ow.any(ow.string, ow.buffer, ow.object))) {
+        if (options.contentType && !(ow.isValid(value, ow.any(ow.string, ow.buffer)) || (ow.isValid(value, ow.object) && typeof value?.pipe === 'function'))) {
             throw new ArgumentError('The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.', this.setValue);
         }
         ow(options, ow.object.exactShape({

--- a/src/storages/key_value_store.js
+++ b/src/storages/key_value_store.js
@@ -11,6 +11,7 @@ import { ApifyClient } from 'apify-client';
 import { ApifyStorageLocal } from '@apify/storage-local';
 import { Configuration } from '../configuration';
 import { APIFY_API_BASE_URL } from '../constants';
+import isStream from 'is-stream';
 /* eslint-enable no-unused-vars,import/named,import/no-duplicates,import/order */
 
 /**
@@ -223,8 +224,8 @@ export class KeyValueStore {
             validator: ow.isValid(k, ow.string.matches(KEY_VALUE_STORE_KEY_REGEX)),
             message: 'The "key" argument must be at most 256 characters long and only contain the following characters: a-zA-Z0-9!-_.\'()',
         })));
-        if (options.contentType && !ow.isValid(value, ow.any(ow.string, ow.buffer))) {
-            throw new ArgumentError('The "value" parameter must be a String or Buffer when "options.contentType" is specified.', this.setValue);
+        if (options.contentType && !(ow.isValid(value, ow.any(ow.string, ow.buffer)) || isStream(value))) {
+            throw new ArgumentError('The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.', this.setValue);
         }
         ow(options, ow.object.exactShape({
             contentType: ow.optional.string.nonEmpty,

--- a/test/storages/key_value_store.test.js
+++ b/test/storages/key_value_store.test.js
@@ -1,6 +1,7 @@
 import {
     ENV_VARS,
 } from '@apify/consts';
+import { PassThrough } from 'stream';
 import { apifyClient } from '../../build/utils';
 import {
     KeyValueStore,
@@ -8,7 +9,6 @@ import {
 } from '../../build/storages/key_value_store';
 import { StorageManager } from '../../build/storages/storage_manager';
 import Apify from '../../build';
-import { PassThrough } from 'stream';
 
 jest.mock('../../build/storages/storage_manager');
 

--- a/test/storages/key_value_store.test.js
+++ b/test/storages/key_value_store.test.js
@@ -8,6 +8,7 @@ import {
 } from '../../build/storages/key_value_store';
 import { StorageManager } from '../../build/storages/storage_manager';
 import Apify from '../../build';
+import { PassThrough } from 'stream';
 
 jest.mock('../../build/storages/storage_manager');
 
@@ -125,10 +126,10 @@ describe('KeyValueStore remote', () => {
             await expect(async () => store.setValue(123, 'some value'))
                 .rejects.toThrow('Expected argument to be of type `string` but received type `number`');
 
-            const valueErrMsg = 'The "value" parameter must be a String or Buffer when "options.contentType" is specified';
+            const valueErrMsg = 'The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified';
             await expect(async () => store.setValue('key', {}, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
             await expect(async () => store.setValue('key', 12345, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
-            await expect(async () => store.setValue('key', () => {}, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
+            await expect(async () => store.setValue('key', () => { }, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
 
             await expect(async () => store.setValue('key', {}, 123))
                 .rejects.toThrow('Expected argument to be of type `object` but received type `number`');
@@ -148,10 +149,10 @@ describe('KeyValueStore remote', () => {
 
             const contTypeRedundantErrMsg = 'Expected property string `contentType` to not be empty in object';
             await expect(async () => store.setValue('key', null, { contentType: 'image/png' }))
-                .rejects.toThrow('The "value" parameter must be a String or Buffer when "options.contentType" is specified.');
+                .rejects.toThrow('The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.');
             await expect(async () => store.setValue('key', null, { contentType: '' })).rejects.toThrow(contTypeRedundantErrMsg);
             await expect(async () => store.setValue('key', null, { contentType: {} }))
-                .rejects.toThrow('The "value" parameter must be a String or Buffer when "options.contentType" is specified.');
+                .rejects.toThrow('The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.');
 
             await expect(async () => store.setValue('key', 'value', { contentType: 123 }))
                 .rejects.toThrow('Expected property `contentType` to be of type `string` but received type `number` in object');
@@ -271,6 +272,30 @@ describe('KeyValueStore remote', () => {
                 key: 'key-1',
                 value,
                 contentType: 'image/jpeg; charset=something',
+            });
+        });
+
+        test('correctly passes a stream', async () => {
+            const store = new KeyValueStore({
+                id: 'my-store-id-1',
+                client: apifyClient,
+            });
+
+            const mockSetRecord = jest
+                .spyOn(store.client, 'setRecord')
+                .mockResolvedValueOnce(null);
+
+            const value = new PassThrough();
+            await store.setValue('key-1', value, { contentType: 'plain/text' });
+            value.emit('data', 'hello world');
+            value.end();
+            value.destroy();
+
+            expect(mockSetRecord).toHaveBeenCalledTimes(1);
+            expect(mockSetRecord).toHaveBeenCalledWith({
+                key: 'key-1',
+                value,
+                contentType: 'plain/text',
             });
         });
     });


### PR DESCRIPTION
Right now the only way for a stream to be save in a KV store is using a buffer but (correct me if I'm wrong), that would mean using the memory (while passing the stream would directly send it via the network to the s3 bucket).

Current working solution:
```js
async function concatStreamToBuffer(stream) {
    return new Promise((resolve, reject) => {
        const chunks = [];
        stream
            .on('data', (chunk) => {
                chunks.push(chunk);
            })
            .on('error', (e) => reject(e))
            .on('end', () => {
                const buffer = Buffer.concat(chunks);
                return resolve(buffer);
            });
    });
}

Apify.main(async () => {
    const store = await Apify.openKeyValueStore();

    const videoStream = new Stream();
    // ...
    const videoBuffer = await concatStreamToBuffer(videoStream);
    await store.setValue('video', videoBuffer, { contentType: 'video/mp4' });
});
```

The PR would let us do:
```js
Apify.main(async () => {
    const store = await Apify.openKeyValueStore();
    const videoStream = new Stream();
    // ...
    await store.setValue('movie', videoStream, { contentType: 'video/mp4' });
});
```

Thoughts?

---
We uncovered this issue while working on a project with @levent91.