### PR TITLE
feat: add `playwright.utils.injectJQuery`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.3.1 / TBA
 ====================
 - fix: `utils.apifyClient` early instantiation (#1330)
+- feat: `playwright.injectJQuery()` (#1337)
 
 2.3.0 / 2022/04/07
 ====================

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -49,10 +49,6 @@ const injectedFilesCache = new LruCache({ maxLength: MAX_INJECT_FILE_CACHE_SIZE 
  *   Enables the injected script to survive page navigations and reloads without need to be re-injected manually.
  *   This does not mean, however, that internal state will be preserved. Just that it will be automatically
  *   re-injected on each navigation before any other scripts get the chance to execute.
- * @param {boolean} [options.waitForDOMLoad]
- *   With this option set, the script gets re-injected only after finished DOM load. This is necessary for some scripts
- *   requiring the global `document` object.
- *   This option is ignored when `surviveNavigations` is set to `false`.
  * @return {Promise<*>}
  * @memberOf puppeteer
  */
@@ -61,7 +57,6 @@ const injectFile = async (page, filePath, options = {}) => {
     ow(filePath, ow.string);
     ow(options, ow.object.exactShape({
         surviveNavigations: ow.optional.boolean,
-        waitForDOMLoad: ow.optional.boolean,
     }));
 
     let contents = injectedFilesCache.get(filePath);
@@ -71,12 +66,11 @@ const injectFile = async (page, filePath, options = {}) => {
     }
     const evalP = page.evaluate(contents);
 
-    if (options.surviveNavigations) {
-        return options.waitForDOMLoad
-            ? Promise.all([page.on('domcontentloaded', async () => { await page.evaluate(contents); }), evalP])
-            : Promise.all([page.evaluateOnNewDocument(contents), evalP]);
-    }
-    return evalP;
+    return options.surviveNavigations
+        ? Promise.all([page.on('framenavigated', async () => {
+            await page.evaluate(contents);
+        }), evalP])
+        : evalP;
 };
 
 /**
@@ -109,7 +103,7 @@ const injectFile = async (page, filePath, options = {}) => {
  */
 const injectJQuery = (page) => {
     ow(page, ow.object.validate(validators.browserPage));
-    return injectFile(page, jqueryPath, { surviveNavigations: true, waitForDOMLoad: true });
+    return injectFile(page, jqueryPath, { surviveNavigations: true });
 };
 
 /**

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -1,7 +1,6 @@
-import fs from 'fs';
+import { readFile } from 'fs/promises';
 import ow from 'ow';
 import vm from 'vm';
-import util from 'util';
 import _ from 'underscore';
 import { LruCache } from '@apify/datastructures';
 import { Page, Response, DirectNavigationOptions } from 'puppeteer'; // eslint-disable-line no-unused-vars
@@ -14,7 +13,6 @@ import { openKeyValueStore } from './storages/key_value_store';
 
 const jqueryPath = require.resolve('jquery');
 const underscorePath = require.resolve('underscore');
-const readFilePromised = util.promisify(fs.readFile);
 
 const MAX_INJECT_FILE_CACHE_SIZE = 10;
 const DEFAULT_BLOCK_REQUEST_URL_PATTERNS = ['.css', '.jpg', '.jpeg', '.png', '.svg', '.gif', '.woff', '.pdf', '.zip'];
@@ -61,16 +59,18 @@ const injectFile = async (page, filePath, options = {}) => {
 
     let contents = injectedFilesCache.get(filePath);
     if (!contents) {
-        contents = await readFilePromised(filePath, 'utf8');
+        contents = await readFile(filePath, 'utf8');
         injectedFilesCache.add(filePath, contents);
     }
     const evalP = page.evaluate(contents);
 
-    return options.surviveNavigations
-        ? Promise.all([page.on('framenavigated', async () => {
-            await page.evaluate(contents);
-        }), evalP])
-        : evalP;
+    if (options.surviveNavigations) {
+        page.on('framenavigated',
+            () => page.evaluate(contents)
+                .catch((error) => log.warning('An error occured during the script injection!', { error })));
+    }
+
+    return evalP;
 };
 
 /**

--- a/test/playwright_utils.test.js
+++ b/test/playwright_utils.test.js
@@ -1,5 +1,6 @@
 import playwright from 'playwright';
 import express from 'express';
+import path from 'path';
 import Apify from '../build/index';
 import LocalStorageDirEmulator from './local_storage_dir_emulator';
 import { startExpressAppPromise } from './_helper';
@@ -52,28 +53,108 @@ describe('Apify.utils.playwright', () => {
         await localStorageEmulator.destroy();
     });
 
-    test('gotoExtended() works', async () => {
-        const browser = await playwright.chromium.launch({ headless: true });
+    describe.each([
+        // ['launchPuppeteer', { launchOptions: { headless: true } }],
+        ['launchPlaywright', { launchOptions: { headless: true } }],
+    ])('with %s', (launchName, launchContext) => {
+        test('injectFile()', async () => {
+        /* eslint-disable no-shadow */
+            const browser = await Apify[launchName](launchContext);
+            const survive = async (browser) => {
+            // Survive navigations
+                const page = await browser.newPage();
+                let result = await page.evaluate(() => window.injectedVariable === 42);
+                expect(result).toBe(false);
+                await Apify.utils.playwright.injectFile(page, path.join(__dirname, 'data', 'inject_file.txt'), { surviveNavigations: true });
+                result = await page.evaluate(() => window.injectedVariable);
+                expect(result).toBe(42);
+                await page.goto('about:chrome');
+                result = await page.evaluate(() => window.injectedVariable);
+                expect(result).toBe(42);
+                await page.goto('https://www.example.com');
+                result = await page.evaluate(() => window.injectedVariable);
+                expect(result).toBe(42);
+            };
+            const remove = async (browser) => {
+            // Remove with navigations
+                const page = await browser.newPage();
+                let result = await page.evaluate(() => window.injectedVariable === 42);
+                expect(result).toBe(false);
+                await page.goto('about:chrome');
+                result = await page.evaluate(() => window.injectedVariable === 42);
+                expect(result).toBe(false);
+                await Apify.utils.playwright.injectFile(page, path.join(__dirname, 'data', 'inject_file.txt'));
+                result = await page.evaluate(() => window.injectedVariable);
+                expect(result).toBe(42);
+                await page.goto('https://www.example.com');
+                result = await page.evaluate(() => window.injectedVariable === 42);
+                expect(result).toBe(false);
+            };
+            try {
+                await Promise.all([survive(browser), remove(browser)]);
+            } finally {
+                browser.close();
+            }
+        });
 
-        try {
-            const page = await browser.newPage();
-            const request = new Apify.Request({
-                url: `http://${HOSTNAME}:${port}/foo`,
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json; charset=utf-8',
-                },
-                payload: '{ "foo": "bar" }',
-            });
+        test('injectJQuery()', async () => {
+            const browser = await Apify[launchName](launchContext);
 
-            const response = await Apify.utils.playwright.gotoExtended(page, request);
+            try {
+                const page = await browser.newPage();
+                await page.goto('about:blank');
 
-            const { method, headers, bodyLength } = JSON.parse(await response.text());
-            expect(method).toBe('POST');
-            expect(bodyLength).toBe(16);
-            expect(headers['content-type']).toBe('application/json; charset=utf-8');
-        } finally {
-            await browser.close();
-        }
-    }, 60000);
+                // NOTE: Chrome already defines window.$ as alias to document.querySelector(),
+                // (https://developers.google.com/web/tools/chrome-devtools/console/command-line-reference#queryselector)
+                const result1 = await page.evaluate(() => {
+                    return {
+                        isDefined: window.jQuery !== undefined,
+                    };
+                });
+                expect(result1).toEqual({
+                    isDefined: false,
+                });
+
+                await Apify.utils.playwright.injectJQuery(page);
+                const result2 = await page.evaluate(() => {
+                /* global $ */
+                    return {
+                        isDefined: window.jQuery === window.$,
+                        text: $('h1').text(),
+                    };
+                });
+                expect(result2).toEqual({
+                    isDefined: true,
+                    text: '',
+                });
+            } finally {
+                browser.close();
+            }
+        });
+
+        test('gotoExtended() works', async () => {
+            const browser = await playwright.chromium.launch({ headless: true });
+
+            try {
+                const page = await browser.newPage();
+                const request = new Apify.Request({
+                    url: `http://${HOSTNAME}:${port}/foo`,
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json; charset=utf-8',
+                    },
+                    payload: '{ "foo": "bar" }',
+                });
+
+                const response = await Apify.utils.playwright.gotoExtended(page, request);
+
+                const { method, headers, bodyLength } = JSON.parse(await response.text());
+                expect(method).toBe('POST');
+                expect(bodyLength).toBe(16);
+                expect(headers['content-type']).toBe('application/json; charset=utf-8');
+            } finally {
+                await browser.close();
+            }
+        }, 60000);
+    });
 });

--- a/test/playwright_utils.test.js
+++ b/test/playwright_utils.test.js
@@ -93,7 +93,7 @@ describe('Apify.utils.playwright', () => {
             try {
                 await Promise.all([survive(browser), remove(browser)]);
             } finally {
-                browser.close();
+                await browser.close();
             }
         });
 
@@ -116,6 +116,7 @@ describe('Apify.utils.playwright', () => {
                 });
 
                 await Apify.utils.playwright.injectJQuery(page);
+
                 const result2 = await page.evaluate(() => {
                 /* global $ */
                     return {
@@ -127,8 +128,21 @@ describe('Apify.utils.playwright', () => {
                     isDefined: true,
                     text: '',
                 });
+
+                await page.reload();
+
+                const result3 = await page.evaluate(() => {
+                    return {
+                        isDefined: window.jQuery === window.$,
+                        text: $('h1').text(),
+                    };
+                });
+                expect(result3).toEqual({
+                    isDefined: true,
+                    text: '',
+                });
             } finally {
-                browser.close();
+                await browser.close();
             }
         });
 

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -93,11 +93,11 @@ describe('Apify.utils.puppeteer', () => {
             try {
                 await Promise.all([survive(browser), remove(browser)]);
             } finally {
-                browser.close();
+                await browser.close();
             }
         });
 
-        test('injectJQuery()', async () => {
+        test.only('injectJQuery()', async () => {
             const browser = await Apify[launchName](launchContext);
 
             try {
@@ -127,8 +127,21 @@ describe('Apify.utils.puppeteer', () => {
                     isDefined: true,
                     text: '',
                 });
+
+                await page.reload();
+
+                const result3 = await page.evaluate(() => {
+                    return {
+                        isDefined: window.jQuery === window.$,
+                        text: $('h1').text(),
+                    };
+                });
+                expect(result3).toEqual({
+                    isDefined: true,
+                    text: '',
+                });
             } finally {
-                browser.close();
+                await browser.close();
             }
         });
 
@@ -151,7 +164,7 @@ describe('Apify.utils.puppeteer', () => {
                 });
                 expect(result2).toEqual({ isDefined: true });
             } finally {
-                browser.close();
+                await browser.close();
             }
         });
 
@@ -319,7 +332,7 @@ describe('Apify.utils.puppeteer', () => {
                 expect(typeof content).toBe('string');
                 expect(content).toBe('<html><head></head><body></body></html>');
             } finally {
-                browser.close();
+                await browser.close();
             }
         });
 

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -97,7 +97,7 @@ describe('Apify.utils.puppeteer', () => {
             }
         });
 
-        test.only('injectJQuery()', async () => {
+        test('injectJQuery()', async () => {
             const browser = await Apify[launchName](launchContext);
 
             try {


### PR DESCRIPTION
closes #1336

JQuery requires the global `document` object, which is not available when `Page.addInitScript`-s are added. This solution, therefore, introduces the new `injectFile` option `waitForDOM`, which ensures the script does not get injected until the DOM load.

The implementation of `waitForDOM` needs rework. Loading bigger scripts (as JQuery, for instance) takes a longer time and introduces "race condition," as there is no way of waiting for the script load to finish. This makes testing + usage a guessing game.