### PR TITLE
fix: ensure failed req count is correct when using `RequestList`

### DIFF
--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -645,7 +645,7 @@ export class BasicCrawler {
             // Mark the request as failed and do not retry.
             this.handledRequestsCount++;
             await source.markRequestHandled(request);
-            this.stats.failJob(request.id || request.url);
+            this.stats.failJob(request.id || request.uniqueKey);
             crawlingContext.error = error;
             await this._handleFailedRequestFunction(crawlingContext); // This function prints an error message.
         }


### PR DESCRIPTION
When using `RequestList`, the `request.id` is not there so we use the `uniqueKey` to track the `request`, but to fail it, we used the `url`.