### PR TITLE
fix: random puppeteer crawler (running in headful mode) failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: `utils.apifyClient` early instantiation (#1330)
 - feat: `utils.playwright.injectJQuery()` (#1337)
 - feat: add `keyValueStore` option to `Statistics` class (#1345)
+- fix: random puppeteer crawler (running in headful mode) failure (#1348)
 
 2.3.0 / 2022/04/07
 ====================

--- a/src/browser_launchers/puppeteer_launcher.js
+++ b/src/browser_launchers/puppeteer_launcher.js
@@ -135,6 +135,12 @@ export class PuppeteerLauncher extends BrowserLauncher {
         const launchOptions = super.createLaunchOptions();
         launchOptions.args = launchOptions.args || [];
 
+        // Adding the following flag should prevent actor run failure for puppeteer crawler running in headful mode.
+        // Related to https://github.com/puppeteer/puppeteer/issues/7050.
+        if (!launchOptions.headless) {
+            launchOptions.args.push('--disable-site-isolation-trials');
+        }
+
         if (isAtHome()) launchOptions.args.push('--no-sandbox');
 
         if (launchOptions.defaultViewport === undefined) {


### PR DESCRIPTION
This should fix the random failure of actor runs using puppeteer crawler in headful mode. It first appeared in SDK 2.3.0 after updating puppeteer to version 13.

Seems like the issue appeared in puppeteer [a long time](https://github.com/puppeteer/puppeteer/issues/3309) ago, and is still [not fixed](https://github.com/puppeteer/puppeteer/issues/7050). The last puppeteer version working without this issue is 10.4.0. My bet is it's related to OOP iframes changes in [v11](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0). The issue is pretty random though and hard to reproduce. Sometimes it happens after 1-2 requests are processed, sometimes after 10-15 minutes run, sometimes run could finish successfully. Adding `--disable-site-isolation-trials` flag fixes it.

No need to add this flag to headless though. Also - the playwright seems to be working fine, so it's puppeteer-related only.