### PR TITLE
fix: use default user agent for playwright with chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.3.2 / 2022/05/05
+====================
+- fix: use default user agent for playwright with chrome instead of the default "headless UA"
+
+
 2.3.1 / 2022/05/03
 ====================
 - fix: `utils.apifyClient` early instantiation (#1330)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.3.2 / 2022/05/05
 ====================
 - fix: use default user agent for playwright with chrome instead of the default "headless UA"
+- fix: always hide webdriver of chrome browsers
 
 
 2.3.1 / 2022/05/03

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@apify/timeout": "^0.2.1",
         "@apify/utilities": "^1.2.8",
         "apify-client": "^2.3.1",
-        "browser-pool": "^3.1.2",
+        "browser-pool": "^3.1.3",
         "cheerio": "1.0.0-rc.10",
         "content-type": "^1.0.4",
         "got-scraping": "^3.2.9",

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,9 +2,9 @@ import { ACTOR_EVENT_NAMES } from '@apify/consts';
 
 /**
  * The default user agent used by `Apify.launchPuppeteer`.
- * Last updated on 2020-05-22.
+ * Last updated on 2022-05-05.
  */
-export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36';
+export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36';
 
 /**
  * Exit codes for the actor process.

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@ import { ACTOR_EVENT_NAMES } from '@apify/consts';
  * The default user agent used by `Apify.launchPuppeteer`.
  * Last updated on 2020-05-22.
  */
-export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36';
+export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.15 Safari/537.36';
 
 /**
  * Exit codes for the actor process.

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@ import { ACTOR_EVENT_NAMES } from '@apify/consts';
  * The default user agent used by `Apify.launchPuppeteer`.
  * Last updated on 2020-05-22.
  */
-export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.15 Safari/537.36';
+export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36';
 
 /**
  * Exit codes for the actor process.

--- a/test/crawlers/playwright_crawler.test.js
+++ b/test/crawlers/playwright_crawler.test.js
@@ -71,8 +71,7 @@ describe('PlaywrightCrawler', () => {
                 request.userData.title = await page.title();
                 processed.push(request);
                 expect(response.request().headers()['user-agent']).not.toMatch(/headless/i);
-                // TODO uncomment once we have this fixed in browser-pool
-                // await expect(page.evaluate(() => window.navigator.webdriver)).toBeFalsy();
+                await expect(page.evaluate(() => window.navigator.webdriver)).resolves.toBeFalsy();
             };
 
             const playwrightCrawler = new Apify.PlaywrightCrawler({

--- a/test/crawlers/playwright_crawler.test.js
+++ b/test/crawlers/playwright_crawler.test.js
@@ -70,6 +70,9 @@ describe('PlaywrightCrawler', () => {
                 expect(await response.status()).toBe(200);
                 request.userData.title = await page.title();
                 processed.push(request);
+                expect(response.request().headers()['user-agent']).not.toMatch(/headless/i);
+                // TODO uncomment once we have this fixed in browser-pool
+                // await expect(page.evaluate(() => window.navigator.webdriver)).toBeFalsy();
             };
 
             const playwrightCrawler = new Apify.PlaywrightCrawler({

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -87,6 +87,9 @@ describe('PuppeteerCrawler', () => {
             expect(await response.status()).toBe(200);
             request.userData.title = await page.title();
             processed.push(request);
+            expect(response.request().headers()['user-agent']).not.toMatch(/headless/i);
+            // TODO uncomment once we have this fixed in browser-pool
+            // await expect(page.evaluate(() => window.navigator.webdriver)).toBeFalsy();
         };
 
         const puppeteerCrawler = new Apify.PuppeteerCrawler({

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -88,8 +88,7 @@ describe('PuppeteerCrawler', () => {
             request.userData.title = await page.title();
             processed.push(request);
             expect(response.request().headers()['user-agent']).not.toMatch(/headless/i);
-            // TODO uncomment once we have this fixed in browser-pool
-            // await expect(page.evaluate(() => window.navigator.webdriver)).toBeFalsy();
+            await expect(page.evaluate(() => window.navigator.webdriver)).resolves.toBeFalsy();
         };
 
         const puppeteerCrawler = new Apify.PuppeteerCrawler({


### PR DESCRIPTION
Uses predefined UA instead of the default "headless" ones.