### PR TITLE
fix: update utils.enqueueLinks to ignore invalid URLs when using cheerio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.3.3 / TBA
 ====================
 - fix: update `purgeLocalStorage` utility method to mimic `purge` param of `apify run`
+- fix: update `utils.enqueueLinks` to ignore invalid URLs when using cheerio
 
 2.3.2 / 2022/05/05
 ====================

--- a/src/enqueue_links/enqueue_links.js
+++ b/src/enqueue_links/enqueue_links.js
@@ -171,15 +171,20 @@ export function extractUrlsFromCheerio($, selector, baseUrl) {
         .map((i, el) => $(el).attr('href'))
         .get()
         .filter((href) => !!href)
-        .map((href) => {
+        .reduce((urls, current) => {
             // Throw a meaningful error when only a relative URL would be extracted instead of waiting for the Request to fail later.
-            const isHrefAbsolute = /^[a-z][a-z0-9+.-]*:/.test(href); // Grabbed this in 'is-absolute-url' package.
+            const isHrefAbsolute = /^[a-z][a-z0-9+.-]*:/.test(current); // Grabbed this in 'is-absolute-url' package.
             if (!isHrefAbsolute && !baseUrl) {
-                throw new Error(`An extracted URL: ${href} is relative and options.baseUrl is not set. `
+                throw new Error(`An extracted URL: ${current} is relative and options.baseUrl is not set. `
                     + 'Use options.baseUrl in utils.enqueueLinks() to automatically resolve relative URLs.');
             }
-            return baseUrl
-                ? (new URL(href, baseUrl)).href
-                : href;
-        });
+
+            try {
+                urls.push(new URL(current, baseUrl).href);
+            } catch {
+                log.warning(`An extracted URL: ${current} is invalid, ignoring.`);
+            }
+
+            return urls;
+        }, []);
 }


### PR DESCRIPTION
Previously if using the cheerio crawler, the enqueue_links function would error if any href contained a URL that was invalid.

Updated the `extractUrlsFromCheerio` function to gracefully handle invalid relative and absolute URLs. Logging a warning message if an invalid URL is encountered.

Closes #1368 