### PR TITLE
fix: infiniteScroll() not working in Firefox

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -398,25 +398,6 @@ export async function infiniteScroll(page: Page, options: InfiniteScrollOptions 
         }
     });
 
-    // Move mouse to the center of the page, so we can scroll up-down
-    let body = await page.$('body');
-
-    for (let retry = 0; retry < 10; retry++) {
-        if (body) break;
-        await page.waitForTimeout(100);
-        body = await page.$('body');
-    }
-
-    if (!body) {
-        return;
-    }
-
-    const boundingBox = await body.boundingBox();
-    await page.mouse.move(
-        boundingBox!.x + boundingBox!.width / 2,
-        boundingBox!.y + boundingBox!.height / 2,
-    );
-
     const checkFinished = setInterval(() => {
         if (resourcesStats.oldRequested === resourcesStats.newRequested) {
             resourcesStats.matchNumber++;
@@ -455,7 +436,7 @@ export async function infiniteScroll(page: Page, options: InfiniteScrollOptions 
         await doScroll();
         await page.waitForTimeout(250);
         if (scrollDownAndUp) {
-            await page.mouse.wheel(0, -1000);
+            await page.mouse.wheel(0, -100);
         }
         if (buttonSelector) {
             await maybeClickButton();


### PR DESCRIPTION
For unknown reasons, Firefox got hung up on the `mouse.move()` call fairly often - testing didn't show any real benefits from this call, it was most likely a remnant from the Puppeteer utils (still unclear what was it for, even there).

fixes: #1821 