### PR TITLE
fix: stop lerna from overwriting the copy.ts results

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,9 @@
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): %s"
+    },
+    "publish": {
+      "assets": []
     }
   },
   "npmClient": "yarn",


### PR DESCRIPTION
Changes from Lerna v7 (namely [this one](https://github.com/lerna/lerna/pull/3699)) broke our release pipeline. 

This PR reverts the effect of those changes and tells Lerna not to do our work (copy `README` and `package.json` to the released directory).