### PR TITLE
fix: don't call `notify` in `addRequests()`

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -950,14 +950,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      */
     async addRequests(requests: (string | Source)[], options: CrawlerAddRequestsOptions = {}): Promise<CrawlerAddRequestsResult> {
         const requestQueue = await this.getRequestQueue();
-        const res = await requestQueue.addRequestsBatched(requests, options);
-
-        // Notify AutoscaledPool, if it exists, the method is called after the crawler started, and we don't want to wait
-        // this is important for crawlers in `keepAlive` mode that might have an empty queue and we don't want to wait till
-        // the next scheduled check (which might come in as much as 500ms by default).
-        await this.autoscaledPool?.notify();
-
-        return res;
+        return requestQueue.addRequestsBatched(requests, options);
     }
 
     /**


### PR DESCRIPTION
Reverting the `notify` call in `addRequests` because of the call stack issues (#2421 )