### PR TITLE
fix: ensure `PlaywrightGotoOptions` won't result in `unknown` when playwright is not installed

### DIFF
--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -23,7 +23,7 @@ export interface PlaywrightCrawlingContext<UserData extends Dictionary = Diction
         PlaywrightContextUtils {}
 export interface PlaywrightHook extends BrowserHook<PlaywrightCrawlingContext, PlaywrightGotoOptions> {}
 export interface PlaywrightRequestHandler extends BrowserRequestHandler<LoadedContext<PlaywrightCrawlingContext>> {}
-export type PlaywrightGotoOptions = Parameters<Page['goto']>[1];
+export type PlaywrightGotoOptions = Dictionary & Parameters<Page['goto']>[1];
 
 export interface PlaywrightCrawlerOptions
     extends BrowserCrawlerOptions<PlaywrightCrawlingContext, { browserPlugins: [PlaywrightPlugin] }> {

--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,5 @@
 		}
 	],
 	"schedule": ["every weekday"],
-	"ignoreDeps": ["crawlee", "cheerio", "playwright", "yarn"]
+	"ignoreDeps": ["crawlee", "cheerio", "playwright"]
 }


### PR DESCRIPTION
Closes #2994