### PR TITLE
fix(playwright): prevent crashes on closed pages

### DIFF
--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -263,7 +263,7 @@ export class PlaywrightCrawler extends BrowserCrawler<
         } catch (err: any) {
             if (err.message?.includes('Page closed')) {
                 log.warning(`Page closed unexpectedly during navigation: ${request.url}`);
-                // Mark request as failed (optional)
+                // Mark request as failed
                 request.pushErrorMessage(err);
                 // Return undefined to indicate failure (or throw to retry)
                 return;

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -34,11 +34,11 @@ describe('PlaywrightCrawler - page closed handling', () => {
         // Confirm that Crawlee routed the failed request correctly
         expect(failedRequestHandler).toHaveBeenCalledOnce();
 
-        // Optional: Check that the failure was due to the page being closed
+        //Check that the failure was due to the page being closed
         const failedRequest = failedRequestHandler.mock.calls[0][0]?.request;
         const errorMessages = failedRequest?.errorMessages ?? [];
 
-        expect(errorMessages.some(msg => msg.includes('closed'))).toBe(true);
+        expect(errorMessages.some((msg: string | string[]) => msg.includes('closed'))).toBe(true);
     });
 });
 


### PR DESCRIPTION
 ### Summary

 This PR fixes an issue where unhandled `Page closed` errors in `PlaywrightCrawler` could crash actors unexpectedly. The error typically occurs when pages are closed during navigation or handler execution (e.g., due to force quits or browser crashes).

 ### Changes

 * Wrapped `gotoExtended` in `_navigationHandler` with `try/catch`
 * Handled `Page closed` errors and logged them
 * Ensured such requests are retried or routed to `failedRequestHandler`
 * Added a regression test simulating the failure scenario

 ### Related

 Fixes #2779
 Resolves crash in [epctex/traffic-generator](https://apify.com/epctex/traffic-generator) (https://apify.com/epctex/traffic-generator) when terminated abruptly