### PR TITLE
chore(e2e): fix indefinite wait in `puppeteer-store-pagination`

### DIFF
--- a/test/e2e/puppeteer-store-pagination/actor/main.js
+++ b/test/e2e/puppeteer-store-pagination/actor/main.js
@@ -64,7 +64,7 @@ crawler.router.addHandler('DETAIL', async ({ log, page, request: { url } }) => {
     const price = Number(rawPrice.replaceAll(',', ''));
 
     const inStockElement = await page.$('span.product-form__inventory');
-    const inStock = inStockElement?.evaluate((el) => el.textContent.includes('In stock')) ?? false;
+    const inStock = (await inStockElement?.evaluate((el) => el.textContent.includes('In stock'))) ?? false;
 
     const results = {
         url,


### PR DESCRIPTION
The testing page now contains other messages as well (not only `In stock`, see below). `.wait()` call on `In stock` search would timeout with the default 30000 ms timeout.

Other tests (playwright, jquery) seem to only test for the existence of the element (not wait until it's present), so those should be fine.

![image](https://github.com/user-attachments/assets/7976d6e0-8cab-4d1f-b83d-1878e488670f)

![image](https://github.com/user-attachments/assets/85a92d3f-988f-4677-8ac5-50ffa1f58f6c)

![image](https://github.com/user-attachments/assets/8bba7734-e4a6-4f9a-ae75-b26102da7166)

