### PR TITLE
fix: respect `exclude` option in `enqueueLinksByClickingElements`

### DIFF
--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -87,7 +87,6 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * containing patterns matching URLs that will **never** be enqueued.
      *
      * The plain objects must include either the `glob` property or the `regexp` property.
-     * All remaining keys will be used as request options for the corresponding enqueued {@apilink Request} objects.
      *
      * Glob matching is always case-insensitive.
      * If you need case-sensitive matching, provide a regexp.

--- a/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
@@ -76,7 +76,6 @@ export interface EnqueueLinksByClickingElementsOptions {
      * containing patterns matching URLs that will **never** be enqueued.
      *
      * The plain objects must include either the `glob` property or the `regexp` property.
-     * All remaining keys will be used as request options for the corresponding enqueued {@apilink Request} objects.
      *
      * Glob matching is always case-insensitive.
      * If you need case-sensitive matching, provide a regexp.

--- a/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
@@ -76,7 +76,6 @@ export interface EnqueueLinksByClickingElementsOptions {
      * containing patterns matching URLs that will **never** be enqueued.
      *
      * The plain objects must include either the `glob` property or the `regexp` property.
-     * All remaining keys will be used as request options for the corresponding enqueued {@apilink Request} objects.
      *
      * Glob matching is always case-insensitive.
      * If you need case-sensitive matching, provide a regexp.


### PR DESCRIPTION
Related to https://github.com/apify/apify-sdk-js/issues/410 (closes this issue once Crawlee and generic Actors are released).

We should eventually support all the options from `enqueueLinks` in `enqueueLinksByClickingElements`, but the current design would require duplicating all of the code. 

The biggest reason why we cannot reuse code by calling `enqueueLinks` from `enqueueLinksByClickingElements` is currently the implementation of `createInterceptRequestHandler`:

https://github.com/apify/crawlee/blob/136e3adbb03dbb381ca51f79432ae679b383533a/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts#L344-L351

`enqueueLinks` only accepts `urls` option as of now, which would require us to drop the other request fields.

Alternatively, we can also drop the `enqueueLinksByClickingElements` helper in v4, as it hasn't proved useful for many users. 