### PR TITLE
chore(ci): move ZenHub cards for draft PRs to the "In Progress" column

### DIFF
--- a/.github/workflows/update_zenhub_pipeline.yml
+++ b/.github/workflows/update_zenhub_pipeline.yml
@@ -10,7 +10,7 @@ on:
       - edited
       - ready_for_review
     branches:
-      - main
+      - master
 
 jobs:
   move_zenhub_cards:


### PR DESCRIPTION
As per the request of @nicklamonov , this CI workflow moves draft PRs (their linked issues) to the `In Progress` ZenHub pipeline.

Tested over at https://github.com/apify/store-website-content-crawler/ .