### PR TITLE
perf: Improve glob performance by reusing minimatch objects

### DIFF
--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -176,12 +176,8 @@ export function createRequests(
     strategy?: EnqueueLinksOptions['strategy'],
     onSkippedUrl?: (url: string) => void,
 ): Request[] {
-    const excludePatternObjectMatchers = excludePatternObjects.map((excludePatternObject) =>
-        createPatternObjectMatchers(excludePatternObject),
-    );
-    const urlPatternObjectMatchers = urlPatternObjects?.map((urlPatternObject) =>
-        createPatternObjectMatchers(urlPatternObject),
-    );
+    const excludePatternObjectMatchers = excludePatternObjects.map(createPatternObjectMatcher);
+    const urlPatternObjectMatchers = urlPatternObjects?.map(createPatternObjectMatcher);
 
     return requestOptions
         .map((opts) => ({ url: typeof opts === 'string' ? opts : opts.url, opts }))
@@ -228,7 +224,7 @@ export function filterRequestsByPatterns(
     }
 
     const filtered: Request[] = [];
-    const patternMatchers = patterns?.map((pattern) => createPatternObjectMatchers(pattern));
+    const patternMatchers = patterns?.map(createPatternObjectMatcher);
 
     for (const request of requests) {
         const matchingPattern = patternMatchers.find(({ match }) => match(request.url));
@@ -285,7 +281,7 @@ export function createRequestOptions(
 /**
  * @ignore
  */
-function createPatternObjectMatchers(urlPatternObject: UrlPatternObject) {
+function createPatternObjectMatcher(urlPatternObject: UrlPatternObject) {
     const { regexp, glob } = urlPatternObject;
     let match;
     if (regexp) {


### PR DESCRIPTION
If a site has a lot of links and a lot of exclude globs, then it takes forever for `await enqueueLinks({ exclude: input.excludeUrlGlobs })` to match the requests.

```js
const sources = Array(2_000).fill(undefined).map((_, i) => `http://example.com/page-${i}`);
const requestOptions = createRequestOptions(sources);
const urlPatternObjects = Array(10).fill(undefined).map((_, i) => ({ glob: `http://example.com/page-${i}` }));
const excludePatternObjects = Array(4_000).fill(undefined).map((_, i) => ({ glob: `http://example.com/exclude-${i}` }));
const requests = createRequests(requestOptions, urlPatternObjects, excludePatternObjects);
```

Test results on mac M3:

Before:

```
48396ms
```

After:

```
2583ms
```

On apify platform (that has probably slower CPUs) it takes 15m+ (actor timeout) to handle 13000 exclude globs with a page that has ~900 links

https://console.apify.com/organization/aOPfQq4XINDWub5lR/actors/aYG0l9s7dbB7j3gbS/issues/98l4JyUBg03GYolHJ

https://console.apify.com/view/runs/KrZAKDW3o4iTPtS9m