### PR TITLE
docs: fix sidebar rendering in API docs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -34,7 +34,7 @@
         "typescript": "^5.8.3"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^4.4.5",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.4.8",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "3.9.1",
         "@docusaurus/faster": "3.9.1",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -354,7 +354,6 @@ article .card h2 {
 .menu__link,
 .table-of-contents__link {
     text-overflow: ellipsis;
-    display: inline-block;
     width: 100%;
     overflow: hidden;
     white-space: nowrap;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -256,7 +256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/docusaurus-plugin-typedoc-api@npm:^4.4.5":
+"@apify/docusaurus-plugin-typedoc-api@npm:^4.4.8":
   version: 4.4.8
   resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.4.8"
   dependencies:
@@ -14590,7 +14590,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.4.5"
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.4.8"
     "@apify/eslint-config-ts": "npm:^0.4.0"
     "@apify/tsconfig": "npm:^0.1.0"
     "@apify/utilities": "npm:^2.8.0"


### PR DESCRIPTION
Fixes extensive spacing in API docs navbar

|before|after|
|---|---|
|<img width="976" height="665" alt="image" src="https://github.com/user-attachments/assets/4d410515-f440-48f7-9964-8f75d96ae27b" /> | <img width="976" height="665" alt="image" src="https://github.com/user-attachments/assets/f825f71f-d734-449b-adc8-9f6d62c37d10" /> |

Connected to https://github.com/apify/crawlee-python/issues/1439