### PR TITLE
docs: missing `url` param on page view [internal]

### DIFF
--- a/website/src/plugins/docusaurus-plugin-segment/segment.js
+++ b/website/src/plugins/docusaurus-plugin-segment/segment.js
@@ -1,15 +1,18 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export default ExecutionEnvironment.canUseDOM ? {
-    onRouteUpdate({ location }) {
-        // Don't track page views on development
-        if (process.env.NODE_ENV === 'production' && window.analytics) {
-            window.analytics.page({
-                app: 'crawlee',
-                path: location.pathname,
-                url: location.href,
-                search: location.search,
-            });
-        }
+    onRouteUpdate() {
+        // this forces deferred execution that ensures `window.location` is in sync
+        setTimeout(() => {
+            // Don't track page views on development
+            if (process.env.NODE_ENV === 'production' && window.analytics) {
+                window.analytics.page({
+                    app: 'crawlee',
+                    path: window.location.pathname,
+                    url: window.location.href,
+                    search: window.location.search,
+                });
+            }
+        }, 0);
     },
 } : null;


### PR DESCRIPTION
supports https://github.com/apify/apify-web/issues/5377
- turned out that `location` from docusaurus doesn't provide `url` 😂 
- using `window.location` instead does the trick