### PR TITLE
fix: await retries inside `_timeoutAndRetry`

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1695,7 +1695,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         retried = 1,
     ): Promise<T> {
         try {
-            return addTimeoutToPromise(handler, timeout, error);
+            return await addTimeoutToPromise(handler, timeout, error);
         } catch (e) {
             if (retried <= maxRetries) {
                 // we retry on any error, not just timeout


### PR DESCRIPTION
Fixes https://github.com/apify/crawlee/pull/3188#discussion_r2410256271 in a separate PR for clean history and review

~Returns the value from the callback inside `_timeoutAndRetry()`, so we can reuse the return value without having to use `let` variables and assigning to them inside the callbacks 🙏~

EDIT: this turned into a fix in the end :D Here is the reasoning:
- https://github.com/apify/crawlee/pull/3206#issuecomment-3436804306