### PR TITLE
fix: make old ZenHub flow work properly for fork PRs

### DIFF
--- a/.github/workflows/update_zenhub_pipeline.yml
+++ b/.github/workflows/update_zenhub_pipeline.yml
@@ -1,7 +1,7 @@
 name: Synchronize ZenHub pipeline with Pull Request status
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
I mean this will be removable soon anyways, but yknow :D