### PR TITLE
ci: Fix retrying in NPM publish workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -96,7 +96,7 @@ jobs:
                   timeout_minutes: 10
                   max_attempts: 5
                   retry_wait_seconds: 30
-                  command: yarn publish:prod --yes --no-verify-access
+                  command: git checkout . && yarn publish:prod --yes
               env:
                   GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Fixes errors observed in https://github.com/apify/crawlee/actions/runs/19128588676/job/54663734151
    - there was a warning about --no-verify-access being deprecated
    - the `publish:prod` command makes changes to package.json files and then it cries about uncommitted stuff when we retry it - I decided to just drop those changes so that it can make them again and happily trot into the sunset
