### PR TITLE
perf: drop `tsbuildinfo` from published packages

### DIFF
--- a/packages/basic-crawler/tsconfig.build.json
+++ b/packages/basic-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/browser-crawler/tsconfig.build.json
+++ b/packages/browser-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/browser-pool/tsconfig.build.json
+++ b/packages/browser-pool/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/cheerio-crawler/tsconfig.build.json
+++ b/packages/cheerio-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/crawlee/tsconfig.build.json
+++ b/packages/crawlee/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/http-crawler/tsconfig.build.json
+++ b/packages/http-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/impit-client/tsconfig.build.json
+++ b/packages/impit-client/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/jsdom-crawler/tsconfig.build.json
+++ b/packages/jsdom-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/linkedom-crawler/tsconfig.build.json
+++ b/packages/linkedom-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/memory-storage/tsconfig.build.json
+++ b/packages/memory-storage/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/playwright-crawler/tsconfig.build.json
+++ b/packages/playwright-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/puppeteer-crawler/tsconfig.build.json
+++ b/packages/puppeteer-crawler/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/templates/tsconfig.build.json
+++ b/packages/templates/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.build.json",
 	"compilerOptions": {
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"rootDir": "./src"
 	},
 	"include": ["src/**/*"]
 }


### PR DESCRIPTION
Sets `rootDir` (the common root of all build inputs) in Crawlee packages to `./src`. This causes the `tsbuildinfo` files to get generated in the package root folder (the one with `package.json`) rather than `/dist`.

The `tsbuildinfo` files are around 175 kB for each package, so this shrinks all packages by this number of bytes. E.g. `@crawlee/cheerio`  is 218 kB of unpacked size as of `3.15.3`, so this is a sizable improvement.

Closes #3239 