### PR TITLE
chore(e2e): fix faulty assertion in `storage-open-return-storage-object` e2e test

### DIFF
--- a/test/e2e/storage-open-return-storage-object/actor/main.js
+++ b/test/e2e/storage-open-return-storage-object/actor/main.js
@@ -1,4 +1,4 @@
-import { Actor, KeyValueStore, Dataset } from 'apify';
+import { Actor, Dataset, KeyValueStore } from 'apify';
 
 const mainOptions = {
     exit: Actor.isAtHome(),

--- a/test/e2e/storage-open-return-storage-object/test.mjs
+++ b/test/e2e/storage-open-return-storage-object/test.mjs
@@ -25,9 +25,12 @@ const datasetStorageObject = parsed.datasetStorageObject;
 const keyValueStorageObject = parsed.keyValueStorageObject;
 
 await expect(datasetStorageObject.id !== null, 'datasetStorageObject contains id');
-await expect(datasetStorageObject.name !== null, 'datasetStorageObject contains name');
+await expect(
+    [null, 'default'].includes(datasetStorageObject.name),
+    'Default dataset\'s name is either "default" or null',
+);
 await expect(datasetStorageObject.userId !== null, 'datasetStorageObject contains userId');
 
 await expect(keyValueStorageObject.id !== null, 'keyValueStorageObject contains id');
-await expect(keyValueStorageObject.name !== null, 'keyValueStorageObject contains name');
+await expect([null, 'default'].includes(keyValueStorageObject.name), 'Default KVS\'s name is either "default" or null');
 await expect(keyValueStorageObject.userId !== null, 'keyValueStorageObject contains userId');


### PR DESCRIPTION
Apify API returns `null` for the default dataset's `name`, local storage implementations return `'default'`. 

Because of #3251, the e2e tests have been passing despite this issue.