### PR TITLE
chore(e2e): fix flaky e2e test orchestration

### DIFF
--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -159,10 +159,7 @@ if (isMainThread) {
     try {
         if (process.env.STORAGE_IMPLEMENTATION === 'LOCAL') {
             console.log('Temporary installing @apify/storage-local');
-            execSync(
-                `yarn add -D "@apify/storage-local@https://registry.npmjs.org/@apify/storage-local/-/storage-local-2.3.1-beta.1.tgz"`,
-                { stdio: 'inherit' },
-            );
+            execSync(`yarn add -D "@apify/storage-local@^2.3.1-beta.1"`, { stdio: 'inherit' });
         }
         if (process.env.STORAGE_IMPLEMENTATION !== 'PLATFORM') {
             console.log('Fetching Camoufox...');


### PR DESCRIPTION
Fixes the latest failing E2E test problems ([e.g. here](https://github.com/apify/crawlee/actions/runs/19523422101/job/55891192021#step:12:18)).

Testing E2E [running here](https://github.com/apify/crawlee/actions/runs/19531539592).