### PR TITLE
chore: add nginx conf and deploy workflow

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -1,0 +1,24 @@
+# Triggers deployment of the Nginx reverse proxy configuration for crawlee.dev
+# when the configuration file is updated in this repository.
+name: Deploy Nginx Configuration
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'website/nginx.conf'
+
+jobs:
+  trigger-deployment:
+    name: Trigger Nginx deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deployment workflow in apify-docs-private
+        run: |
+          gh workflow run deploy-nginx.yml \
+            --repo apify/apify-docs-private \
+            --field deployment=crawlee-docs
+          echo "✅ Deployment workflow triggered successfully"
+        env:
+          GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -1,0 +1,33 @@
+# Nginx reverse proxy configuration for crawlee.dev
+# Routes to GitHub Pages and handles legacy URL redirects
+server {
+    listen 0.0.0.0:8080;
+    server_name 'crawlee.dev';
+    location / {
+        proxy_pass https://apify.github.io/crawlee/;
+    }
+    location /python {
+        proxy_pass https://apify.github.io/crawlee-python/;
+    }
+
+    # So that we can have both GH pages and crawlee.dev/python working and loading assets from the same path
+    location /crawlee-python {
+        proxy_pass https://apify.github.io/crawlee-python/;
+    }
+
+    # Redirect rule for old JS docs to go under /js prefix
+    rewrite ^/docs(.*)$ /js/docs$1 permanent;
+    rewrite ^/api(.*)$ /js/api$1 permanent;
+
+    # Remove version numbers from /js/api/3.[0-9]/* and /js/docs/3.[0-9]/*
+    rewrite ^/js/api/3\.\d(/.*)?$ /js/api$1 permanent;
+    rewrite ^/js/docs/3\.\d(/.*)?$ /js/docs$1 permanent;
+
+    # Redirect rule for "upgrading-to-v03" to "upgrading-to-v0x"
+    rewrite ^/python/docs/upgrading/upgrading-to-v03$ /python/docs/upgrading/upgrading-to-v0x permanent;
+
+    # Redirect rule so that /python/docs actually leads somewhere
+    rewrite ^/python/docs/?$ /python/docs/quick-start;
+
+    rewrite ^/versions/?$ /js/api/core/changelog permanent;
+}


### PR DESCRIPTION
Nginx will be deployed on change in `nginx.conf` file on master branch. Currently, the triggered workflow in `apify-docs-private` does nothing, so it completely safe to merge it. This will be used, when we separate `crawlee` from `apify-docs` nginx.