### PR TITLE
feat: use exclusively the cookies from `Session`

### DIFF
--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -110,3 +110,7 @@ The crawling context in the `FileDownload` crawler no longer includes the `body`
 ## `KeyValueStore.getPublicUrl` is now async
 
 The `KeyValueStore.getPublicUrl` method is now asynchronous and reads the public URL directly from the storage client.
+
+## Cookies now live only in `Session`s
+
+Cookies are now stored only in `Session` objects. To update the cookies for the current session, use `session.setCookie` and `session.getCookieString` methods. The crawler no longer accepts cookies from other sources like `Request` objects or `GotOptions`.

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -42,7 +42,6 @@ import {
     EventType,
     GotScrapingHttpClient,
     KeyValueStore,
-    mergeCookies,
     NonRetryableError,
     purgeDefaultStorages,
     RequestHandlerError,
@@ -1946,17 +1945,6 @@ export class BasicCrawler<
         }
 
         await this.autoscaledPool?.abort();
-    }
-
-    protected _getCookieHeaderFromRequest(request: Request) {
-        if (request.headers?.Cookie && request.headers?.cookie) {
-            this.log.warning(
-                `Encountered mixed casing for the cookie headers for request ${request.url} (${request.id}). Their values will be merged.`,
-            );
-            return mergeCookies(request.url, [request.headers.cookie, request.headers.Cookie]);
-        }
-
-        return request.headers?.Cookie || request.headers?.cookie || '';
     }
 
     private async _getRequestQueue() {

--- a/packages/basic-crawler/src/internals/send-request.ts
+++ b/packages/basic-crawler/src/internals/send-request.ts
@@ -1,4 +1,4 @@
-import { type BaseHttpClient, type HttpRequestOptions, type Request, type Session } from '@crawlee/core';
+import { type BaseHttpClient, type Request, type Session } from '@crawlee/core';
 
 /**
  * Prepares a function to be used as the `sendRequest` context helper.
@@ -10,15 +10,7 @@ import { type BaseHttpClient, type HttpRequestOptions, type Request, type Sessio
  * @param getProxyUrl A function that will return the proxy URL that should be used for handling the request.
  */
 export function createSendRequest(httpClient: BaseHttpClient, originRequest: Request, session: Session | undefined) {
-    return async (overrideOptions: Partial<HttpRequestOptions> = {}): Promise<Response> => {
-        const cookieJar = session
-            ? {
-                  getCookieString: async (url: string) => session.getCookieString(url),
-                  setCookie: async (rawCookie: string, url: string) => session.setCookie(rawCookie, url),
-                  ...overrideOptions?.cookieJar,
-              }
-            : overrideOptions?.cookieJar;
-
-        return httpClient.sendRequest(originRequest.intoFetchAPIRequest(), { session, cookieJar: cookieJar as any });
+    return async (): Promise<Response> => {
+        return httpClient.sendRequest(originRequest.intoFetchAPIRequest(), { session, cookieJar: session?.cookieJar as any });
     };
 }

--- a/packages/core/src/http_clients/base-http-client.ts
+++ b/packages/core/src/http_clients/base-http-client.ts
@@ -4,28 +4,7 @@ import type { AllowedHttpMethods } from '@crawlee/types';
 import { applySearchParams, type SearchParams } from '@crawlee/utils';
 
 import type { Session } from '../session_pool/session.js';
-
-// TODO BC with got - remove the options and callback parameters in 4.0
-interface ToughCookieJar {
-    getCookieString: ((
-        currentUrl: string,
-        options: Record<string, unknown>,
-        callback: (error: Error | null, cookies: string) => void,
-    ) => string) &
-        ((url: string, callback: (error: Error | null, cookieHeader: string) => void) => string);
-    setCookie: ((
-        cookieOrString: unknown,
-        currentUrl: string,
-        options: Record<string, unknown>,
-        callback: (error: Error | null, cookie: unknown) => void,
-    ) => void) &
-        ((rawCookie: string, url: string, callback: (error: Error | null, result: unknown) => void) => void);
-}
-
-interface PromiseCookieJar {
-    getCookieString: (url: string) => Promise<string>;
-    setCookie: (rawCookie: string, url: string) => Promise<unknown>;
-}
+import { CookieJar } from 'tough-cookie';
 
 /**
  * HTTP Request as accepted by {@apilink BaseHttpClient} methods.
@@ -39,7 +18,6 @@ export interface HttpRequest {
     signal?: AbortSignal;
     timeout?: number;
 
-    cookieJar?: ToughCookieJar | PromiseCookieJar;
     followRedirect?: boolean | ((response: any) => boolean); // TODO BC with got - specify type better in 4.0
     maxRedirects?: number;
 
@@ -93,7 +71,7 @@ export type RedirectHandler = (
 
 export interface SendRequestOptions {
     session?: Session;
-    cookieJar?: ToughCookieJar;
+    cookieJar?: CookieJar;
     timeout?: number;
 }
 


### PR DESCRIPTION
Makes the current  `Session` instance the single source of cookies for the current request. 

Closes #2744 