### PR TITLE
docs: fix the overlapping `LLMButtons` dropdown

### DIFF
--- a/website/src/components/LLMButtons.module.css
+++ b/website/src/components/LLMButtons.module.css
@@ -66,7 +66,7 @@
 .menuDropdown {
   position: absolute;
   right: 0;
-  margin-top: 0.5rem;
+  top: calc(100% + 0.5rem);
   padding: 0.375rem;
   border-radius: 0.75rem;
   border: 1px solid var(--color-separator);


### PR DESCRIPTION
Fix the overllaping Menu
<img width="295" height="342" alt="image" src="https://github.com/user-attachments/assets/6a667bc6-20c4-4bc2-ab59-3345f7ded3f9" />
