### PR TITLE
fix: handle multiple `BasicCrawler.stop()` calls correctly

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -841,6 +841,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                             'and all requests that were in progress at that time have now finished. ' +
                             `In total, the crawler processed ${this.handledRequestsCount} requests and will shut down.`,
                     );
+                    this.shouldLogShuttingDown = false;
                     return true;
                 }
 
@@ -848,6 +849,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     this.log.info(
                         'The crawler has finished all the remaining ongoing requests and will shut down now.',
                     );
+                    this.shouldLogShuttingDown = false;
                     return true;
                 }
 


### PR DESCRIPTION
`BasicCrawler.stop()` calls asynchronous functions without awaiting them, which can cause unexpected race conditions. This PR ensures that multiple `.stop()` calls only result in one `AutoscaledPool.abort()` call and that the `.stop()`-induced promises are resolved before the main `BasicCrawler.run()` call resolves.

Closes #3257