### PR TITLE
fix(http-crawler): isolate proxy ALPN cache per attempt

### DIFF
--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -807,7 +807,10 @@ export class HttpCrawler<
             proxyUrl,
             timeout: { request: this.navigationTimeoutMillis },
             cookieJar: this.persistCookiesPerSession ? session?.cookieJar : undefined,
-            sessionToken: session,
+            // `got-scraping` uses a global ALPN resolve queue when `sessionToken` is not set.
+            // That queue key does not include the proxy URL, so a hanging proxy CONNECT from one attempt can poison retries that rotate proxies.
+            // Providing a unique token per proxied request forces `got-scraping` to scope those caches per request attempt.
+            sessionToken: session ?? (proxyUrl ? { proxyUrl } : undefined),
             ...gotOptions,
             headers: { ...request.headers, ...gotOptions?.headers },
             https: {


### PR DESCRIPTION
## Problem
When `HttpCrawler` uses `GotScrapingHttpClient` with a rotating `ProxyConfiguration` (`proxyUrls: [...]`), a proxy CONNECT hang can poison retries:

- Attempt 0 hits a proxy that accepts `CONNECT` but never responds (or otherwise hangs during proxy/ALPN negotiation).
- `HttpCrawler` correctly increments `retryCount` and rotates to the next proxy.
- Even though `proxyInfo.url` changes, the retry never reaches the next proxy and times out again.

Root cause: `got-scraping` relies on `http2-wrapper` / `resolve-alpn` for ALPN negotiation. If `sessionToken` is not set, the internal resolve queue/cache is global and keyed only by the target `host:port` (it does **not** include the proxy URL). A pending/hung resolve created by the first proxy attempt can therefore block subsequent retries even if they rotate to a different proxy.

## Reproduction
A new regression test reproduces this deterministically:

- Local HTTPS target server.
- "Hanging" HTTP proxy: accepts `CONNECT` and keeps the socket open without replying.
- "Working" HTTP proxy: properly tunnels `CONNECT` to the HTTPS target.
- `HttpCrawler` config: `maxRequestRetries: 1`, `navigationTimeoutSecs: 1`, `useSessionPool: false`, `ignoreSslErrors: true`, `proxyConfiguration` with `[hangingProxy, workingProxy]`.

Run:

```bash
yarn vitest run test/core/crawlers/http_crawler.test.ts -t "proxy CONNECT hang"
```

Before the fix, the second proxy is never reached (no CONNECT observed) and the retry times out again.

## Fix
When a proxy is used and there is no `Session` object (e.g. `useSessionPool: false`), `HttpCrawler` now sets a unique `sessionToken` for proxied requests. This scopes `got-scraping`'s internal ALPN resolve caches per attempt (instead of the global queue), so a hanging proxy CONNECT cannot poison retries that rotate proxies.

- No public API changes.
- Requests without a proxy are unaffected.
- If a `Session` is already present, `sessionToken` continues to be derived from it as before.
