### PR TITLE
test: fix flaky requestHandlerTimeoutSecs test

### DIFF
--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -427,6 +427,7 @@ describe('BrowserCrawler', () => {
         await localStorageEmulator.init();
         const puppeteerPlugin = new PuppeteerPlugin(puppeteer);
 
+        vitest.useFakeTimers({ shouldAdvanceTime: true });
         try {
             const requestList = await RequestList.open({
                 sources: [{ url: `${serverAddress}/?q=1` }],
@@ -452,6 +453,7 @@ describe('BrowserCrawler', () => {
             expect(callSpy).toBeCalledTimes(1);
             expect(callSpy).toBeCalledWith('good');
         } finally {
+            vitest.useRealTimers();
             await localStorageEmulator.destroy();
         }
     });


### PR DESCRIPTION
## Summary
- Fix flaky test `should respect the requestHandlerTimeoutSecs option` in `browser_crawler.test.ts`
- Use Vitest fake timers with `shouldAdvanceTime: true` to prevent timer leakage
- The 1500ms "bad" timer was remaining in the event loop and firing during other concurrent tests

## Test plan
- [x] Verified the test passes consistently (ran 5 times in a row)
- [x] The fix uses the same fake timer pattern as other tests in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)