### PR TITLE
fix: remove deprecation from `RequestQueueV1`

### DIFF
--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -72,8 +72,6 @@ const RECENTLY_HANDLED_CACHE_SIZE = 1000;
  * await queue.addRequest({ url: 'http://example.com/foo/bar' }, { forefront: true });
  * ```
  * @category Sources
- *
- * @deprecated RequestQueue v1 is deprecated and will be removed in the future. Please use {@apilink RequestQueue} instead.
  */
 class RequestQueue extends RequestProvider {
     private queryQueueHeadPromise?: Promise<{


### PR DESCRIPTION
## Summary
- Remove `@deprecated` JSDoc tag from `RequestQueueV1` class
- This class remains a valid fallback for users encountering issues with the default `RequestQueue` (v2 with locking)
- The deprecation notice was misleading as the class will continue to be supported

## Test plan
- [x] Verified no other deprecation mentions exist for RequestQueueV1 in the codebase
- [x] Documentation in `docs/experiments/request_locking.mdx` correctly describes RequestQueueV1 as a fallback option

🤖 Generated with [Claude Code](https://claude.com/claude-code)