### PR TITLE
fix(impit-client): pause fromWeb stream to prevent early consumption

### DIFF
--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -1,4 +1,4 @@
-import { Readable, Transform } from 'node:stream';
+import { pipeline, Readable, Transform } from 'node:stream';
 import { type ReadableStream } from 'node:stream/web';
 import { isGeneratorObject } from 'node:util/types';
 
@@ -217,7 +217,9 @@ export class ImpitHttpClient implements BaseHttpClient {
             },
         });
 
-        responseStream.pipe(counter);
+        pipeline(responseStream, counter, (err) => {
+            if (err) counter.destroy(err);
+        });
 
         const getDownloadProgress = () => ({
             percent: total > 0 ? Math.round((transferred / total) * 100) : 0,


### PR DESCRIPTION
Attaching a 'data' listener on Readable.fromWeb(response.body) switches the stream into flowing mode. This can start consuming the response body before Crawlee attaches its pipeline consumer, so initial chunks are lost and the downstream sees a truncated stream. That also aswers why only retries worked.

Fix: call responseStream.pause() right after registering the 'data' handler. The stream stays paused until the pipeline/pipe attaches and resumes it, preventing early consumption while still allowing progress tracking.

Closes [WCC issue #555](https://github.com/apify/store-website-content-crawler/issues/555)