### PR TITLE
chore: clean turbo cache and tsbuildinfo files in yarn clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "scripts": {
         "postinstall": "npx husky install",
         "prepublishOnly": "turbo run copy",
-        "clean": "turbo run clean",
+        "clean": "turbo run clean && rimraf .turbo packages/*/.turbo packages/*/*.tsbuildinfo",
         "build": "turbo run build && node ./scripts/typescript_fixes.mjs",
         "ci:build": "turbo run build --cache-dir=\".turbo\" && node ./scripts/typescript_fixes.mjs",
         "test": "vitest run --silent",


### PR DESCRIPTION
## Summary
- Updated `yarn clean` script to also remove turbo cache directories (`.turbo/` at root and `packages/*/.turbo`) and TypeScript build info files (`packages/*/*.tsbuildinfo`)
- This prevents stale turbo cache from causing build failures

## Test plan
- [x] Ran `yarn clean && yarn build` successfully after the change

🤖 Generated with [Claude Code](https://claude.ai/code)