### PR TITLE
chore: bump impit version in `@crawlee/impit-client`

### DIFF
--- a/packages/impit-client/package.json
+++ b/packages/impit-client/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@apify/datastructures": "^2.0.3",
-        "impit": "^0.8.0",
+        "impit": "^0.9.0",
         "tough-cookie": "^6.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,7 @@ __metadata:
   dependencies:
     "@apify/datastructures": "npm:^2.0.3"
     "@crawlee/core": "npm:^3.15.3"
-    impit: "npm:^0.8.0"
+    impit: "npm:^0.9.0"
     tough-cookie: "npm:^6.0.0"
   peerDependencies:
     "@crawlee/core": ^3.12.1
@@ -7487,9 +7487,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-darwin-arm64@npm:0.8.1"
+"impit-darwin-arm64@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-darwin-arm64@npm:0.9.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -7501,9 +7501,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-darwin-x64@npm:0.8.1"
+"impit-darwin-x64@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-darwin-x64@npm:0.9.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -7515,9 +7515,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-linux-arm64-gnu@npm:0.8.1"
+"impit-linux-arm64-gnu@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-linux-arm64-gnu@npm:0.9.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -7529,9 +7529,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-linux-arm64-musl@npm:0.8.1"
+"impit-linux-arm64-musl@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-linux-arm64-musl@npm:0.9.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -7543,9 +7543,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-linux-x64-gnu@npm:0.8.1"
+"impit-linux-x64-gnu@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-linux-x64-gnu@npm:0.9.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -7557,9 +7557,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-linux-x64-musl@npm:0.8.1"
+"impit-linux-x64-musl@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-linux-x64-musl@npm:0.9.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -7571,9 +7571,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-win32-arm64-msvc@npm:0.8.1"
+"impit-win32-arm64-msvc@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-win32-arm64-msvc@npm:0.9.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -7585,9 +7585,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.8.1":
-  version: 0.8.1
-  resolution: "impit-win32-x64-msvc@npm:0.8.1"
+"impit-win32-x64-msvc@npm:0.9.0":
+  version: 0.9.0
+  resolution: "impit-win32-x64-msvc@npm:0.9.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7625,18 +7625,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit@npm:^0.8.0":
-  version: 0.8.1
-  resolution: "impit@npm:0.8.1"
+"impit@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "impit@npm:0.9.0"
   dependencies:
-    impit-darwin-arm64: "npm:0.8.1"
-    impit-darwin-x64: "npm:0.8.1"
-    impit-linux-arm64-gnu: "npm:0.8.1"
-    impit-linux-arm64-musl: "npm:0.8.1"
-    impit-linux-x64-gnu: "npm:0.8.1"
-    impit-linux-x64-musl: "npm:0.8.1"
-    impit-win32-arm64-msvc: "npm:0.8.1"
-    impit-win32-x64-msvc: "npm:0.8.1"
+    impit-darwin-arm64: "npm:0.9.0"
+    impit-darwin-x64: "npm:0.9.0"
+    impit-linux-arm64-gnu: "npm:0.9.0"
+    impit-linux-arm64-musl: "npm:0.9.0"
+    impit-linux-x64-gnu: "npm:0.9.0"
+    impit-linux-x64-musl: "npm:0.9.0"
+    impit-win32-arm64-msvc: "npm:0.9.0"
+    impit-win32-x64-msvc: "npm:0.9.0"
   dependenciesMeta:
     impit-darwin-arm64:
       optional: true
@@ -7654,7 +7654,7 @@ __metadata:
       optional: true
     impit-win32-x64-msvc:
       optional: true
-  checksum: 10c0/c109e608287aaafd2971d9864baef4d537e3e79eaf57f9fb6250849035e5a74657b329588466da81598d01cc396f34371316b63bd39cb48b07cb4b1ff68bda21
+  checksum: 10c0/52c777a3c2a62492690bd9cd21a2d7cd22fcece51284d26efc76727692b10636c2e3072e8cdb6c7a4de7e5edd016ad1f8a8d8ecba7afdf7f43d14d0c4d434df2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Allows `@crawlee/impit-client` users to access the features from the new `impit` update (high concurrency + OOM patches, more browser fingerprints).