### PR TITLE
chore: set new `v4` packages as `private` to fix `lerna` publishing

### DIFF
--- a/packages/got-scraping-client/package.json
+++ b/packages/got-scraping-client/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@crawlee/got-scraping-client",
     "version": "4.0.0",
+    "private": true,
     "description": "The scalable web crawling and scraping library for JavaScript/Node.js. Enables development of data extraction and web automation jobs (not only) with headless Chrome and Puppeteer.",
     "engines": {
         "node": ">=22.0.0"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@crawlee/http-client",
     "version": "4.0.0",
+    "private": true,
     "description": "The scalable web crawling and scraping library for JavaScript/Node.js. Enables development of data extraction and web automation jobs (not only) with headless Chrome and Puppeteer.",
     "engines": {
         "node": ">=22.0.0"


### PR DESCRIPTION
`lerna` publishing for v4 now [doesn't work](https://github.com/apify/crawlee/actions/runs/21752381523/job/62753386657) because of the new packages missing from `npm`. This sets these packages as `private` to skip the publishing for them for now.