### PR TITLE
chore: add support for a local vitest config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs
 pids
 .idea
 .vscode
+.zed
 package-lock.json
 tmp
 jsconfig.json

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -37,6 +37,7 @@ const baseConfig = defineConfig({
             { find: '@crawlee/cheerio', replacement: resolve(__dirname, './packages/cheerio-crawler/src') },
             { find: '@crawlee/playwright', replacement: resolve(__dirname, './packages/playwright-crawler/src') },
             { find: '@crawlee/puppeteer', replacement: resolve(__dirname, './packages/puppeteer-crawler/src') },
+            { find: '@crawlee/stagehand', replacement: resolve(__dirname, './packages/stagehand-crawler/src') },
             { find: /^@crawlee\/(.*)\/(.*)$/, replacement: resolve(__dirname, './packages/$1/$2') },
             { find: /^@crawlee\/(.*)$/, replacement: resolve(__dirname, './packages/$1/src') },
             { find: /^test\/(.*)$/, replacement: resolve(__dirname, './test/$1') },


### PR DESCRIPTION
**Motivation:** My CPU has 6 normal cores and 8 slow ones, so when vitest tries to utilize all of them, it makes my laptop unusable. So I need a way to customize the vitest config, and this is what worked for me.
