### PR TITLE
chore: use lint-staged in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn format
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -115,6 +115,9 @@
         "typescript-eslint": "^8.28.0",
         "vitest": "^4.0.16"
     },
+    "lint-staged": {
+        "**/*.{js,ts,mjs,mts,cjs,cts,json,css}": "biome format --write --no-errors-on-unmatched"
+    },
     "packageManager": "yarn@4.10.3",
     "volta": {
         "node": "24.13.0",


### PR DESCRIPTION
At the moment lint-staged is installed but it is just dangling in repo and it is not used. Pre-commit hook runs `yarn format` on whole codebase instead of staged files. This also create state where after commit multiple files can be changed, usually followed by `lint:fix` commit (or similar)

After this merged:
- lint-staged will run biome --format only on staged files, automatically add changes to commit (if any)
- as it not working on a whole repo, execution should be even faster

Alternative is remove lint-staged from dependencies as we do not use it :-] 