### PR TITLE
fix(cli): fix build errors with TypeScript v5.9 and inquirer import

### DIFF
--- a/packages/cli/src/commands/CreateProjectCommand.ts
+++ b/packages/cli/src/commands/CreateProjectCommand.ts
@@ -9,7 +9,7 @@ import type { Template } from '@crawlee/templates';
 import { fetchManifest } from '@crawlee/templates';
 import colors from 'ansi-colors';
 import { ensureDir } from 'fs-extra';
-import { prompt } from 'inquirer';
+import inquirer from 'inquirer';
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 
 interface CreateProjectArgs {
@@ -138,12 +138,12 @@ export class CreateProjectCommand<T> implements CommandModule<T, CreateProjectAr
 
         // Check proper format of projectName
         if (!projectName) {
-            const projectNamePrompt = await prompt([
+            const projectNamePrompt = await inquirer.prompt([
                 {
                     name: 'projectName',
                     message: 'Name of the new project folder:',
                     type: 'input',
-                    validate: (promptText) => {
+                    validate: (promptText: string) => {
                         try {
                             validateProjectName(promptText);
                         } catch (err: any) {
@@ -165,7 +165,7 @@ export class CreateProjectCommand<T> implements CommandModule<T, CreateProjectAr
         }));
 
         if (!template) {
-            const answer = await prompt([
+            const answer = await inquirer.prompt([
                 {
                     type: 'list',
                     name: 'template',

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -4,5 +4,5 @@
 		"outDir": "./dist",
 		"rootDir": "./src"
 	},
-	"include": ["src/**/*"]
+	"include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
PROBLEM:

@crawlee/cli fails to build with TypeScript v5.9.x due to two issues in CreateProjectCommand.ts:

1. Module '"inquirer"' has no exported member 'prompt' :
 TS 5.9 tightened named export resolution for packages without a corresponding @types/ installation. Since @types/inquirer is not present, { prompt } can no longer be resolved as a named export from inquirer v8.
2. Parameter 'promptText' implicitly has an 'any' type
This is now flagged under stricter type inference in TS 5.9.

Additionally, packages/types/tsconfig.build.json was using src/**/* as the include glob. Because compiled .js files are present in src/, TypeScript was attempting to process non-TS files during the build. 
--> Build should complete with 0 errors. Previously failed with exit code 2 on `@crawlee/cli#build`.


CHANGES:

1. Replaced import { prompt } from 'inquirer' with a default import and updated usages to inquirer.prompt() 
2. Added an explicit string type annotation to the promptText parameter in the validation callback
3. Narrowed the include glob in packages/types/tsconfig.build.json from "src/**/*" to "src/**/*.ts" to avoid picking up compiled JS files

Tested with TypeScript 5.9.3. **Build and test suite pass**.

