### PR TITLE
feat: share `SessionPool` instance between crawlers

### DIFF
--- a/docs/guides/session_management_basic.ts
+++ b/docs/guides/session_management_basic.ts
@@ -1,4 +1,4 @@
-import { BasicCrawler, ProxyConfiguration } from 'crawlee';
+import { BasicCrawler, ProxyConfiguration, SessionPool } from 'crawlee';
 import { Impit } from 'impit';
 import { Cookie } from 'tough-cookie';
 
@@ -8,7 +8,7 @@ const proxyConfiguration = new ProxyConfiguration({
 
 const crawler = new BasicCrawler({
     // Overrides default Session pool configuration.
-    sessionPoolOptions: { maxPoolSize: 100 },
+    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
     async requestHandler({ request, session }) {
         const { url } = request;
         const client = new Impit({

--- a/docs/guides/session_management_basic.ts
+++ b/docs/guides/session_management_basic.ts
@@ -8,7 +8,7 @@ const proxyConfiguration = new ProxyConfiguration({
 
 const crawler = new BasicCrawler({
     // Overrides default Session pool configuration.
-    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
+    sessionPool: new SessionPool({ maxPoolSize: 100 }),
     async requestHandler({ request, session }) {
         const { url } = request;
         const client = new Impit({

--- a/docs/guides/session_management_cheerio.ts
+++ b/docs/guides/session_management_cheerio.ts
@@ -8,7 +8,7 @@ const crawler = new CheerioCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration.
-    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
+    sessionPool: new SessionPool({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookie header to request automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_cheerio.ts
+++ b/docs/guides/session_management_cheerio.ts
@@ -1,4 +1,4 @@
-import { CheerioCrawler, ProxyConfiguration } from 'crawlee';
+import { CheerioCrawler, ProxyConfiguration, SessionPool } from 'crawlee';
 
 const proxyConfiguration = new ProxyConfiguration({
     /* opts */
@@ -8,7 +8,7 @@ const crawler = new CheerioCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration.
-    sessionPoolOptions: { maxPoolSize: 100 },
+    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookie header to request automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_http.ts
+++ b/docs/guides/session_management_http.ts
@@ -1,4 +1,4 @@
-import { HttpCrawler, ProxyConfiguration } from 'crawlee';
+import { HttpCrawler, ProxyConfiguration, SessionPool } from 'crawlee';
 
 const proxyConfiguration = new ProxyConfiguration({
     /* opts */
@@ -8,7 +8,7 @@ const crawler = new HttpCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration.
-    sessionPoolOptions: { maxPoolSize: 100 },
+    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookie header to request automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_http.ts
+++ b/docs/guides/session_management_http.ts
@@ -8,7 +8,7 @@ const crawler = new HttpCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration.
-    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
+    sessionPool: new SessionPool({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookie header to request automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_jsdom.ts
+++ b/docs/guides/session_management_jsdom.ts
@@ -8,7 +8,7 @@ const crawler = new JSDOMCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration.
-    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
+    sessionPool: new SessionPool({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookie header to request automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_jsdom.ts
+++ b/docs/guides/session_management_jsdom.ts
@@ -1,4 +1,4 @@
-import { JSDOMCrawler, ProxyConfiguration } from 'crawlee';
+import { JSDOMCrawler, ProxyConfiguration, SessionPool } from 'crawlee';
 
 const proxyConfiguration = new ProxyConfiguration({
     /* opts */
@@ -8,7 +8,7 @@ const crawler = new JSDOMCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration.
-    sessionPoolOptions: { maxPoolSize: 100 },
+    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookie header to request automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_playwright.ts
+++ b/docs/guides/session_management_playwright.ts
@@ -8,7 +8,7 @@ const crawler = new PlaywrightCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration
-    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
+    sessionPool: new SessionPool({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookies to page before navigation automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_playwright.ts
+++ b/docs/guides/session_management_playwright.ts
@@ -1,4 +1,4 @@
-import { PlaywrightCrawler, ProxyConfiguration } from 'crawlee';
+import { PlaywrightCrawler, ProxyConfiguration, SessionPool } from 'crawlee';
 
 const proxyConfiguration = new ProxyConfiguration({
     /* opts */
@@ -8,7 +8,7 @@ const crawler = new PlaywrightCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration
-    sessionPoolOptions: { maxPoolSize: 100 },
+    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookies to page before navigation automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_puppeteer.ts
+++ b/docs/guides/session_management_puppeteer.ts
@@ -1,4 +1,4 @@
-import { PuppeteerCrawler, ProxyConfiguration } from 'crawlee';
+import { PuppeteerCrawler, ProxyConfiguration, SessionPool } from 'crawlee';
 
 const proxyConfiguration = new ProxyConfiguration({
     /* opts */
@@ -8,7 +8,7 @@ const crawler = new PuppeteerCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration
-    sessionPoolOptions: { maxPoolSize: 100 },
+    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookies to page before navigation automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_puppeteer.ts
+++ b/docs/guides/session_management_puppeteer.ts
@@ -8,7 +8,7 @@ const crawler = new PuppeteerCrawler({
     // To use the proxy IP session rotation logic, you must turn the proxy usage on.
     proxyConfiguration,
     // Overrides default Session pool configuration
-    sessionPool: await SessionPool.open({ maxPoolSize: 100 }),
+    sessionPool: new SessionPool({ maxPoolSize: 100 }),
     // Set to true if you want the crawler to save cookies per session,
     // and set the cookies to page before navigation automatically (default is true).
     persistCookiesPerSession: true,

--- a/docs/guides/session_management_standalone.ts
+++ b/docs/guides/session_management_standalone.ts
@@ -5,8 +5,7 @@ const sessionPoolOptions = {
     maxPoolSize: 100,
 };
 
-// Open Session Pool.
-const sessionPool = await SessionPool.open(sessionPoolOptions);
+const sessionPool = new SessionPool(sessionPoolOptions);
 
 // Get session.
 const session = await sessionPool.getSession();

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -88,6 +88,23 @@ Previously, the crawling context extended a `Record` type, allowing to access an
 
 `Session.retireOnBlockedStatusCodes` is removed. Blocked status code handling is now internal to the crawler. Configure blocked status codes via the `blockedStatusCodes` crawler option (moved from `sessionPoolOptions`).
 
+## `useSessionPool` and `sessionPoolOptions` are removed
+
+The `useSessionPool` and `sessionPoolOptions` options have been removed from the `BasicCrawler` constructor. Every crawler now uses a `SessionPool` by default. Instead of passing `sessionPoolOptions`, create a `SessionPool` instance directly and pass it via the `sessionPool` option.
+
+```typescript
+import { SessionPool } from '@crawlee/core';
+
+const crawler = new BasicCrawler({
+    // The old parameters won't work anymore
+    // useSessionPool: true,
+    // sessionPoolOptions: { maxUsageCount: 5 },
+    sessionPool: new SessionPool({
+        maxUsageCount: 5,
+    }),
+});
+```
+
 ## Remove `experimentalContainers` option
 
 This experimental option relied on an outdated manifest version for browser extensions, it is not possible to achieve this with the currently supported versions.

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -84,6 +84,26 @@ const crawler = new CheerioCrawler({
 
 Previously, the crawling context extended a `Record` type, allowing to access any property. This was changed to a strict type, which means that you can only access properties that are defined in the context.
 
+## `SessionPool` is now lazy-initialized
+
+`SessionPool.open()` static factory method is removed. Create instances with `new SessionPool(options)` instead — all public methods automatically initialize the pool on first use.
+
+`SessionPool.usableSessionsCount` and `SessionPool.retiredSessionsCount` are now async methods instead of synchronous getters. `SessionPool.getState()` is also async now.
+
+**Before:**
+```typescript
+const sessionPool = await SessionPool.open({ maxPoolSize: 100 });
+const count = sessionPool.usableSessionsCount;
+const state = sessionPool.getState();
+```
+
+**After:**
+```typescript
+const sessionPool = new SessionPool({ maxPoolSize: 100 });
+const count = await sessionPool.usableSessionsCount();
+const state = await sessionPool.getState();
+```
+
 ## `retireOnBlockedStatusCodes` is removed from `Session`
 
 `Session.retireOnBlockedStatusCodes` is removed. Blocked status code handling is now internal to the crawler. Configure blocked status codes via the `blockedStatusCodes` crawler option (moved from `sessionPoolOptions`).

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -833,6 +833,7 @@ export class BasicCrawler<
                 ...statisticsOptions,
             });
             this.sessionPoolOptions = {
+                ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
                 ...sessionPoolOptions,
                 log: this.log,
             };

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -670,7 +670,7 @@ export class BasicCrawler<
         maxRequestsPerCrawl: ow.optional.number,
         maxCrawlDepth: ow.optional.number,
         autoscaledPoolOptions: ow.optional.object,
-        sessionPool: ow.optional.object,
+        sessionPool: ow.optional.object.instanceOf(SessionPool),
         sessionPoolOptions: ow.optional.object,
         proxyConfiguration: ow.optional.object.validate(validators.proxyConfiguration),
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -566,7 +566,7 @@ export class BasicCrawler<
     /**
      * A reference to the underlying {@apilink SessionPool} class that manages the crawler's {@apilink Session|sessions}.
      */
-    sessionPool?: SessionPool;
+    sessionPool: SessionPool;
 
     /**
      * A reference to the underlying {@apilink AutoscaledPool} class that manages the concurrency of the crawler.
@@ -641,7 +641,6 @@ export class BasicCrawler<
     protected handledRequestsCount = 0;
     protected statusMessageLoggingInterval: number;
     protected statusMessageCallback?: StatusMessageCallback;
-    protected sessionPoolOptions: SessionPoolOptions;
     protected blockedStatusCodes = new Set<number>();
     protected additionalHttpErrorStatusCodes: Set<number>;
     protected ignoreHttpErrorStatusCodes: Set<number>;
@@ -864,10 +863,10 @@ export class BasicCrawler<
                 ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
                 ...statisticsOptions,
             });
-            this.sessionPoolOptions = {
+            this.sessionPool = new SessionPool({
                 ...sessionPoolOptions,
                 log: this.log,
-            };
+            });
             this.blockedStatusCodes = new Set(blockedStatusCodesInput ?? BLOCKED_STATUS_CODES);
 
             const maxSignedInteger = 2 ** 31 - 1;
@@ -1660,8 +1659,6 @@ export class BasicCrawler<
         // so that the caller can get a reference to it before awaiting the promise returned from run()
         // (otherwise there would be no way)
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions);
-
-        this.sessionPool = new SessionPool(this.sessionPoolOptions);
         this.sessionPool.setMaxListeners(20);
 
         await this.initializeRequestManager();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1661,7 +1661,7 @@ export class BasicCrawler<
         // (otherwise there would be no way)
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions);
 
-        this.sessionPool = await SessionPool.open(this.sessionPoolOptions);
+        this.sessionPool = new SessionPool(this.sessionPoolOptions);
         this.sessionPool.setMaxListeners(20);
 
         await this.initializeRequestManager();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -22,7 +22,6 @@ import type {
     RouterHandler,
     RouterRoutes,
     Session,
-    SessionPoolOptions,
     SkippedRequestCallback,
     Source,
     StatisticsOptions,
@@ -315,15 +314,8 @@ export interface BasicCrawlerOptions<
      * An existing {@apilink SessionPool} instance to use. When provided, the crawler will use this
      * pool directly instead of creating a new one, enabling session sharing across multiple crawlers.
      * The crawler will not tear down a shared pool — the caller is responsible for its lifecycle.
-     * Mutually exclusive with `sessionPoolOptions`.
      */
     sessionPool?: SessionPool;
-
-    /**
-     * The configuration options for {@apilink SessionPool} to use.
-     * Mutually exclusive with `sessionPool`.
-     */
-    sessionPoolOptions?: SessionPoolOptions;
 
     /**
      * Defines the length of the interval for calling the `setStatusMessage` in seconds.
@@ -575,7 +567,7 @@ export class BasicCrawler<
     /**
      * A reference to the underlying {@apilink SessionPool} class that manages the crawler's {@apilink Session|sessions}.
      */
-    sessionPool?: SessionPool;
+    sessionPool: SessionPool;
 
     /**
      * A reference to the underlying {@apilink AutoscaledPool} class that manages the concurrency of the crawler.
@@ -650,7 +642,6 @@ export class BasicCrawler<
     protected handledRequestsCount = 0;
     protected statusMessageLoggingInterval: number;
     protected statusMessageCallback?: StatusMessageCallback;
-    protected sessionPoolOptions: SessionPoolOptions;
     protected blockedStatusCodes = new Set<number>();
     protected additionalHttpErrorStatusCodes: Set<number>;
     protected ignoreHttpErrorStatusCodes: Set<number>;
@@ -659,7 +650,6 @@ export class BasicCrawler<
     protected retryOnBlocked: boolean;
     protected respectRobotsTxtFile: boolean | { userAgent?: string };
     protected onSkippedRequest?: SkippedRequestCallback;
-    private ownsSessionPool = true;
     private _closeEvents?: boolean;
     private loggedPerRun = new Set<string>();
     private experiments: CrawlerExperiments;
@@ -692,7 +682,6 @@ export class BasicCrawler<
         maxCrawlDepth: ow.optional.number,
         autoscaledPoolOptions: ow.optional.object,
         sessionPool: ow.optional.object.instanceOf(SessionPool),
-        sessionPoolOptions: ow.optional.object,
         proxyConfiguration: ow.optional.object.validate(validators.proxyConfiguration),
 
         statusMessageLoggingInterval: ow.optional.number,
@@ -746,8 +735,7 @@ export class BasicCrawler<
             maxCrawlDepth,
             autoscaledPoolOptions = {},
             keepAlive,
-            sessionPool: injectedSessionPool,
-            sessionPoolOptions = {},
+            sessionPool,
             proxyConfiguration,
 
             additionalHttpErrorStatusCodes = [],
@@ -876,21 +864,9 @@ export class BasicCrawler<
                 ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
                 ...statisticsOptions,
             });
-            if (injectedSessionPool) {
-                if (Object.keys(sessionPoolOptions).length > 0) {
-                    throw new Error(
-                        'Cannot use both `sessionPool` and `sessionPoolOptions` — pass either a pre-built SessionPool instance or options to create one, not both.',
-                    );
-                }
-                this.sessionPool = injectedSessionPool;
-                this.ownsSessionPool = false;
-            }
 
-            this.sessionPoolOptions = {
-                ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
-                ...sessionPoolOptions,
-                log: this.log,
-            };
+            this.sessionPool = sessionPool ?? new SessionPool();
+
             this.blockedStatusCodes = new Set(blockedStatusCodesInput ?? BLOCKED_STATUS_CODES);
 
             const maxSignedInteger = 2 ** 31 - 1;
@@ -1297,9 +1273,6 @@ export class BasicCrawler<
 
             this.stats.reset();
             await this.stats.resetStore();
-            if (this.ownsSessionPool) {
-                await this.sessionPool?.resetStore();
-            }
         }
 
         this.unexpectedStop = false;
@@ -1685,10 +1658,6 @@ export class BasicCrawler<
         // so that the caller can get a reference to it before awaiting the promise returned from run()
         // (otherwise there would be no way)
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions);
-
-        if (!this.sessionPool) {
-            this.sessionPool = await SessionPool.open(this.sessionPoolOptions);
-        }
         this.sessionPool.setMaxListeners(20);
 
         await this.initializeRequestManager();
@@ -2247,10 +2216,6 @@ export class BasicCrawler<
      */
     async teardown(): Promise<void> {
         serviceLocator.getEventManager().emit(EventType.PERSIST_STATE, { isMigrating: false });
-
-        if (this.ownsSessionPool) {
-            await this.sessionPool?.teardown();
-        }
 
         if (this._closeEvents) {
             await serviceLocator.getEventManager().close();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -641,6 +641,7 @@ export class BasicCrawler<
     protected handledRequestsCount = 0;
     protected statusMessageLoggingInterval: number;
     protected statusMessageCallback?: StatusMessageCallback;
+    protected sessionPoolOptions?: SessionPoolOptions;
     protected blockedStatusCodes = new Set<number>();
     protected additionalHttpErrorStatusCodes: Set<number>;
     protected ignoreHttpErrorStatusCodes: Set<number>;
@@ -863,10 +864,12 @@ export class BasicCrawler<
                 ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
                 ...statisticsOptions,
             });
-            this.sessionPool = new SessionPool({
+            this.sessionPoolOptions = {
                 ...sessionPoolOptions,
                 log: this.log,
-            });
+            };
+            this.sessionPool = new SessionPool(this.sessionPoolOptions);
+
             this.blockedStatusCodes = new Set(blockedStatusCodesInput ?? BLOCKED_STATUS_CODES);
 
             const maxSignedInteger = 2 ** 31 - 1;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -570,6 +570,11 @@ export class BasicCrawler<
     sessionPool: SessionPool;
 
     /**
+     * Indicates whether the crawler owns the session pool (it was not passed from the outside using the `sessionPool` constructor option).
+     */
+    private ownsSessionPool: boolean;
+
+    /**
      * A reference to the underlying {@apilink AutoscaledPool} class that manages the concurrency of the crawler.
      * > *NOTE:* This property is only initialized after calling the {@apilink BasicCrawler.run|`crawler.run()`} function.
      * We can use it to change the concurrency settings on the fly,
@@ -866,6 +871,9 @@ export class BasicCrawler<
             });
 
             this.sessionPool = sessionPool ?? new SessionPool();
+            this.sessionPool.setMaxListeners(20);
+
+            this.ownsSessionPool = !sessionPool;
 
             this.blockedStatusCodes = new Set(blockedStatusCodesInput ?? BLOCKED_STATUS_CODES);
 
@@ -1273,6 +1281,9 @@ export class BasicCrawler<
 
             this.stats.reset();
             await this.stats.resetStore();
+            if (this.ownsSessionPool) {
+                await this.sessionPool.resetStore();
+            }
         }
 
         this.unexpectedStop = false;
@@ -1658,7 +1669,6 @@ export class BasicCrawler<
         // so that the caller can get a reference to it before awaiting the promise returned from run()
         // (otherwise there would be no way)
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions);
-        this.sessionPool.setMaxListeners(20);
 
         await this.initializeRequestManager();
         await this._loadHandledRequestCount();
@@ -2219,6 +2229,10 @@ export class BasicCrawler<
 
         if (this._closeEvents) {
             await serviceLocator.getEventManager().close();
+        }
+
+        if (this.ownsSessionPool) {
+            await this.sessionPool.teardown();
         }
 
         await this.autoscaledPool?.abort();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -651,7 +651,6 @@ export class BasicCrawler<
     protected statusMessageLoggingInterval: number;
     protected statusMessageCallback?: StatusMessageCallback;
     protected sessionPoolOptions: SessionPoolOptions;
-    private _ownsSessionPool = true;
     protected blockedStatusCodes = new Set<number>();
     protected additionalHttpErrorStatusCodes: Set<number>;
     protected ignoreHttpErrorStatusCodes: Set<number>;
@@ -660,6 +659,7 @@ export class BasicCrawler<
     protected retryOnBlocked: boolean;
     protected respectRobotsTxtFile: boolean | { userAgent?: string };
     protected onSkippedRequest?: SkippedRequestCallback;
+    private ownsSessionPool = true;
     private _closeEvents?: boolean;
     private loggedPerRun = new Set<string>();
     private experiments: CrawlerExperiments;
@@ -883,7 +883,7 @@ export class BasicCrawler<
                     );
                 }
                 this.sessionPool = injectedSessionPool;
-                this._ownsSessionPool = false;
+                this.ownsSessionPool = false;
             }
 
             this.sessionPoolOptions = {
@@ -1297,7 +1297,7 @@ export class BasicCrawler<
 
             this.stats.reset();
             await this.stats.resetStore();
-            if (this._ownsSessionPool) {
+            if (this.ownsSessionPool) {
                 await this.sessionPool?.resetStore();
             }
         }
@@ -2248,7 +2248,7 @@ export class BasicCrawler<
     async teardown(): Promise<void> {
         serviceLocator.getEventManager().emit(EventType.PERSIST_STATE, { isMigrating: false });
 
-        if (this._ownsSessionPool) {
+        if (this.ownsSessionPool) {
             await this.sessionPool?.teardown();
         }
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -311,7 +311,16 @@ export interface BasicCrawlerOptions<
     keepAlive?: boolean;
 
     /**
+     * An existing {@apilink SessionPool} instance to use. When provided, the crawler will use this
+     * pool directly instead of creating a new one, enabling session sharing across multiple crawlers.
+     * The crawler will not tear down a shared pool — the caller is responsible for its lifecycle.
+     * Mutually exclusive with `sessionPoolOptions`.
+     */
+    sessionPool?: SessionPool;
+
+    /**
      * The configuration options for {@apilink SessionPool} to use.
+     * Mutually exclusive with `sessionPool`.
      */
     sessionPoolOptions?: SessionPoolOptions;
 
@@ -624,6 +633,7 @@ export class BasicCrawler<
     protected statusMessageLoggingInterval: number;
     protected statusMessageCallback?: StatusMessageCallback;
     protected sessionPoolOptions: SessionPoolOptions;
+    private _ownsSessionPool = true;
     protected autoscaledPoolOptions: AutoscaledPoolOptions;
     protected httpClient: BaseHttpClient;
     protected retryOnBlocked: boolean;
@@ -660,6 +670,7 @@ export class BasicCrawler<
         maxRequestsPerCrawl: ow.optional.number,
         maxCrawlDepth: ow.optional.number,
         autoscaledPoolOptions: ow.optional.object,
+        sessionPool: ow.optional.object,
         sessionPoolOptions: ow.optional.object,
         proxyConfiguration: ow.optional.object.validate(validators.proxyConfiguration),
 
@@ -710,6 +721,7 @@ export class BasicCrawler<
             maxCrawlDepth,
             autoscaledPoolOptions = {},
             keepAlive,
+            sessionPool: injectedSessionPool,
             sessionPoolOptions = {},
             proxyConfiguration,
 
@@ -832,6 +844,16 @@ export class BasicCrawler<
                 ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
                 ...statisticsOptions,
             });
+            if (injectedSessionPool) {
+                if (Object.keys(sessionPoolOptions).length > 0) {
+                    throw new Error(
+                        'Cannot use both `sessionPool` and `sessionPoolOptions` — pass either a pre-built SessionPool instance or options to create one, not both.',
+                    );
+                }
+                this.sessionPool = injectedSessionPool;
+                this._ownsSessionPool = false;
+            }
+
             this.sessionPoolOptions = {
                 ...(this.hasExplicitId ? { id: this.crawlerId } : {}),
                 ...sessionPoolOptions,
@@ -1236,7 +1258,9 @@ export class BasicCrawler<
 
             this.stats.reset();
             await this.stats.resetStore();
-            await this.sessionPool?.resetStore();
+            if (this._ownsSessionPool) {
+                await this.sessionPool?.resetStore();
+            }
         }
 
         this.unexpectedStop = false;
@@ -1623,7 +1647,9 @@ export class BasicCrawler<
         // (otherwise there would be no way)
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions);
 
-        this.sessionPool = await SessionPool.open(this.sessionPoolOptions);
+        if (!this.sessionPool) {
+            this.sessionPool = await SessionPool.open(this.sessionPoolOptions);
+        }
         this.sessionPool.setMaxListeners(20);
 
         await this.initializeRequestManager();
@@ -2177,7 +2203,9 @@ export class BasicCrawler<
     async teardown(): Promise<void> {
         serviceLocator.getEventManager().emit(EventType.PERSIST_STATE, { isMigrating: false });
 
-        await this.sessionPool?.teardown();
+        if (this._ownsSessionPool) {
+            await this.sessionPool?.teardown();
+        }
 
         if (this._closeEvents) {
             await serviceLocator.getEventManager().close();

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -322,7 +322,6 @@ export abstract class BrowserCrawler<
         launchContext: ow.optional.object,
         headless: ow.optional.any(ow.boolean, ow.string),
         browserPoolOptions: ow.object,
-        sessionPoolOptions: ow.optional.object,
         persistCookiesPerSession: ow.optional.boolean,
         proxyConfiguration: ow.optional.object.validate(validators.proxyConfiguration),
     };

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -361,6 +361,8 @@ export class SessionPool extends EventEmitter {
      * @param options - Override the persistence options provided in the constructor
      */
     async persistState(options?: PersistenceOptions): Promise<void> {
+        await this.initialize();
+
         if (!this.persistenceOptions.enable && !options?.enable) {
             return;
         }

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -66,9 +66,8 @@ export interface SessionPoolOptions {
  * When some session is marked as blocked, it is removed and new one is created instead (the pool never returns an unusable session).
  * Learn more in the {@doclink guides/session-management | Session management guide}.
  *
- * You can create one by calling the {@apilink SessionPool.open} function.
- *
  * Session pool is already integrated into crawlers and is always active.
+ * All public methods are lazy-initialized — the pool initializes itself on first use.
  *
  * You can configure the pool with many options. See the {@apilink SessionPoolOptions}.
  * Session pool is by default persisted in default {@apilink KeyValueStore}.
@@ -78,7 +77,7 @@ export interface SessionPoolOptions {
  * **Advanced usage:**
  *
  * ```javascript
- * const sessionPool = await SessionPool.open({
+ * const sessionPool = new SessionPool({
  *     maxPoolSize: 25,
  *     sessionOptions:{
  *          maxAgeSecs: 10,
@@ -127,13 +126,10 @@ export class SessionPool extends EventEmitter {
     protected _listener!: () => Promise<void>;
     protected events: EventManager;
     protected persistenceOptions: PersistenceOptions;
-    protected isInitialized = false;
 
+    private initPromise?: Promise<void>;
     private queue = new AsyncQueue();
 
-    /**
-     * @internal
-     */
     constructor(options: SessionPoolOptions = {}) {
         super();
 
@@ -186,31 +182,35 @@ export class SessionPool extends EventEmitter {
     /**
      * Gets count of usable sessions in the pool.
      */
-    get usableSessionsCount(): number {
+    async usableSessionsCount(): Promise<number> {
+        await this.initialize();
         return this.sessions.filter((session) => session.isUsable()).length;
     }
 
     /**
      * Gets count of retired sessions in the pool.
      */
-    get retiredSessionsCount(): number {
+    async retiredSessionsCount(): Promise<number> {
+        await this.initialize();
         return this.sessions.filter((session) => !session.isUsable()).length;
     }
 
     /**
      * Starts periodic state persistence and potentially loads SessionPool state from {@apilink KeyValueStore}.
-     * It is called automatically by the {@apilink SessionPool.open} function.
+     * Called automatically on first use of any public method.
      */
     async initialize(): Promise<void> {
-        if (this.isInitialized) {
-            return;
+        if (!this.initPromise) {
+            this.initPromise = this.setupPool();
         }
+        return this.initPromise;
+    }
 
+    private async setupPool(): Promise<void> {
         this.keyValueStore = await KeyValueStore.open(this.persistStateKeyValueStoreId, {
             config: serviceLocator.getConfiguration(),
         });
         if (!this.persistenceOptions.enable) {
-            this.isInitialized = true;
             return;
         }
 
@@ -226,7 +226,6 @@ export class SessionPool extends EventEmitter {
         this._listener = this.persistState.bind(this);
 
         this.events.on(EventType.PERSIST_STATE, this._listener);
-        this.isInitialized = true;
     }
 
     /**
@@ -236,7 +235,7 @@ export class SessionPool extends EventEmitter {
      * @param [options] The configuration options for the session being added to the session pool.
      */
     async addSession(options: Session | SessionOptions = {}): Promise<void> {
-        this._throwIfNotInitialized();
+        await this.initialize();
         const { id } = options;
         if (id) {
             const sessionExists = this.sessionMap.has(id);
@@ -263,7 +262,7 @@ export class SessionPool extends EventEmitter {
      * @param [options] The configuration options for the session being added to the session pool.
      */
     async newSession(sessionOptions?: SessionOptions): Promise<Session> {
-        this._throwIfNotInitialized();
+        await this.initialize();
 
         const newSession = await this.createSessionFunction(this, { sessionOptions });
         this._addSession(newSession);
@@ -292,11 +291,10 @@ export class SessionPool extends EventEmitter {
      * @param [sessionId] If provided, it returns the usable session with this id, `undefined` otherwise.
      */
     async getSession(sessionId?: string): Promise<Session | undefined> {
+        await this.initialize();
+
         await this.queue.wait();
-
         try {
-            this._throwIfNotInitialized();
-
             if (sessionId) {
                 const session = this.sessionMap.get(sessionId);
                 if (session && session.isUsable()) return session;
@@ -327,17 +325,19 @@ export class SessionPool extends EventEmitter {
             return;
         }
 
-        await this.keyValueStore?.setValue(this.persistStateKey, null);
+        await this.initialize();
+        await this.keyValueStore.setValue(this.persistStateKey, null);
     }
 
     /**
      * Returns an object representing the internal state of the `SessionPool` instance.
      * Note that the object's fields can change in future releases.
      */
-    getState() {
+    async getState() {
+        await this.initialize();
         return {
-            usableSessionsCount: this.usableSessionsCount,
-            retiredSessionsCount: this.retiredSessionsCount,
+            usableSessionsCount: await this.usableSessionsCount(),
+            retiredSessionsCount: await this.retiredSessionsCount(),
             sessions: this.sessions.map((session) => session.getState()),
         };
     }
@@ -352,6 +352,8 @@ export class SessionPool extends EventEmitter {
             return;
         }
 
+        await this.initialize();
+
         this.log.debug('Persisting state', {
             persistStateKeyValueStoreId: this.persistStateKeyValueStoreId,
             persistStateKey: this.persistStateKey,
@@ -361,7 +363,7 @@ export class SessionPool extends EventEmitter {
         const persistStateIntervalMillis = serviceLocator.getConfiguration().get('persistStateIntervalMillis')!;
         const timeoutSecs = persistStateIntervalMillis / 2_000;
         await this.keyValueStore
-            .setValue(this.persistStateKey, this.getState(), {
+            .setValue(this.persistStateKey, await this.getState(), {
                 timeoutSecs,
                 doNotRetryTimeouts: true,
             })
@@ -375,15 +377,10 @@ export class SessionPool extends EventEmitter {
      * This function should be called after you are done with using the `SessionPool` instance.
      */
     async teardown(): Promise<void> {
+        if (!this.initPromise) return;
+        await this.initialize();
         this.events.off(EventType.PERSIST_STATE, this._listener);
         await this.persistState();
-    }
-
-    /**
-     * SessionPool should not work before initialization.
-     */
-    protected _throwIfNotInitialized() {
-        if (!this.isInitialized) throw new Error('SessionPool is not initialized.');
     }
 
     /**
@@ -490,18 +487,6 @@ export class SessionPool extends EventEmitter {
             }
         }
 
-        this.log.debug(`${this.usableSessionsCount} active sessions loaded from KeyValueStore`);
-    }
-
-    /**
-     * Opens a SessionPool and returns a promise resolving to an instance
-     * of the {@apilink SessionPool} class that is already initialized.
-     *
-     * For more details and code examples, see the {@apilink SessionPool} class.
-     */
-    static async open(options?: SessionPoolOptions): Promise<SessionPool> {
-        const sessionPool = new SessionPool(options);
-        await sessionPool.initialize();
-        return sessionPool;
+        this.log.debug(`${this.sessions.length} active sessions loaded from KeyValueStore`);
     }
 }

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -46,7 +46,7 @@ export interface SessionPoolOptions {
     persistStateKeyValueStoreId?: string;
 
     /**
-     * Session pool persists it's state under this key in Key value store.
+     * Session pool persists its state under this key in Key value store.
      * @default SDK_SESSION_POOL_STATE_{id}
      */
     persistStateKey?: string;

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -201,7 +201,7 @@ export class SessionPool extends EventEmitter {
      * Starts periodic state persistence and potentially loads SessionPool state from {@apilink KeyValueStore}.
      * It is called automatically by the {@apilink SessionPool.open} function.
      */
-    async initialize(): Promise<void> {
+    protected async initialize(): Promise<void> {
         if (this.isInitialized) {
             return;
         }
@@ -236,7 +236,7 @@ export class SessionPool extends EventEmitter {
      * @param [options] The configuration options for the session being added to the session pool.
      */
     async addSession(options: Session | SessionOptions = {}): Promise<void> {
-        this._throwIfNotInitialized();
+        await this.initialize();
         const { id } = options;
         if (id) {
             const sessionExists = this.sessionMap.has(id);
@@ -263,7 +263,7 @@ export class SessionPool extends EventEmitter {
      * @param [options] The configuration options for the session being added to the session pool.
      */
     async newSession(sessionOptions?: SessionOptions): Promise<Session> {
-        this._throwIfNotInitialized();
+        await this.initialize();
 
         const newSession = await this.createSessionFunction(this, { sessionOptions });
         this._addSession(newSession);
@@ -295,7 +295,7 @@ export class SessionPool extends EventEmitter {
         await this.queue.wait();
 
         try {
-            this._throwIfNotInitialized();
+            await this.initialize();
 
             if (sessionId) {
                 const session = this.sessionMap.get(sessionId);
@@ -377,13 +377,6 @@ export class SessionPool extends EventEmitter {
     async teardown(): Promise<void> {
         this.events.off(EventType.PERSIST_STATE, this._listener);
         await this.persistState();
-    }
-
-    /**
-     * SessionPool should not work before initialization.
-     */
-    protected _throwIfNotInitialized() {
-        if (!this.isInitialized) throw new Error('SessionPool is not initialized.');
     }
 
     /**

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -27,6 +27,13 @@ export interface CreateSession {
 
 export interface SessionPoolOptions {
     /**
+     * Unique identifier for this session pool instance. Used to generate a unique
+     * persistence key when `persistStateKey` is not provided.
+     * If not provided, an auto-incrementing ID is used.
+     */
+    id?: string | number;
+
+    /**
      * Maximum size of the pool. Indicates how many sessions are rotated.
      * @default 1000
      */
@@ -40,7 +47,7 @@ export interface SessionPoolOptions {
 
     /**
      * Session pool persists it's state under this key in Key value store.
-     * @default SESSION_POOL_STATE
+     * @default SDK_SESSION_POOL_STATE_{id}
      */
     persistStateKey?: string;
 
@@ -122,6 +129,9 @@ export interface SessionPoolOptions {
  * @category Scaling
  */
 export class SessionPool extends EventEmitter {
+    private static nextId = 0;
+
+    readonly id: string;
     protected log: CrawleeLogger;
     protected maxPoolSize: number;
     protected createSessionFunction: CreateSession;
@@ -148,6 +158,7 @@ export class SessionPool extends EventEmitter {
         ow(
             options,
             ow.object.exactShape({
+                id: ow.optional.any(ow.number, ow.string),
                 maxPoolSize: ow.optional.number,
                 persistStateKeyValueStoreId: ow.optional.string,
                 persistStateKey: ow.optional.string,
@@ -160,9 +171,10 @@ export class SessionPool extends EventEmitter {
         );
 
         const {
+            id,
             maxPoolSize = MAX_POOL_SIZE,
             persistStateKeyValueStoreId,
-            persistStateKey = PERSIST_STATE_KEY,
+            persistStateKey,
             createSessionFunction,
             sessionOptions = {},
             blockedStatusCodes = BLOCKED_STATUS_CODES,
@@ -172,6 +184,7 @@ export class SessionPool extends EventEmitter {
             },
         } = options;
 
+        this.id = id != null ? String(id) : String(SessionPool.nextId++);
         this.blockedStatusCodes = blockedStatusCodes;
         this.events = serviceLocator.getEventManager();
         this.log = log.child({ prefix: 'SessionPool' });
@@ -191,7 +204,7 @@ export class SessionPool extends EventEmitter {
 
         // Session keyValueStore
         this.persistStateKeyValueStoreId = persistStateKeyValueStoreId;
-        this.persistStateKey = persistStateKey;
+        this.persistStateKey = persistStateKey ?? `${PERSIST_STATE_KEY}_${this.id}`;
     }
 
     /**

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -379,7 +379,9 @@ export class SessionPool extends EventEmitter {
     async teardown(): Promise<void> {
         if (!this.initPromise) return;
         await this.ensureInitialized();
-        this.events.off(EventType.PERSIST_STATE, this._listener);
+        if (this._listener) {
+            this.events.off(EventType.PERSIST_STATE, this._listener);
+        }
         await this.persistState();
     }
 

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -117,13 +117,13 @@ export class SessionPool extends EventEmitter {
     protected log: CrawleeLogger;
     protected maxPoolSize: number;
     protected createSessionFunction: CreateSession;
-    protected keyValueStore!: KeyValueStore;
+    protected keyValueStore?: KeyValueStore;
     protected sessions: Session[] = [];
     protected sessionMap = new Map<string, Session>();
     protected sessionOptions: SessionOptions;
     protected persistStateKeyValueStoreId?: string;
     protected persistStateKey: string;
-    protected _listener!: () => Promise<void>;
+    protected _listener?: () => Promise<void>;
     protected events: EventManager;
     protected persistenceOptions: PersistenceOptions;
 
@@ -225,7 +225,6 @@ export class SessionPool extends EventEmitter {
         await this._maybeLoadSessionPool();
 
         this._listener = this.persistState.bind(this);
-
         this.events.on(EventType.PERSIST_STATE, this._listener);
     }
 
@@ -327,7 +326,7 @@ export class SessionPool extends EventEmitter {
         }
 
         await this.ensureInitialized();
-        await this.keyValueStore.setValue(this.persistStateKey, null);
+        await this.keyValueStore?.setValue(this.persistStateKey, null);
     }
 
     /**
@@ -364,7 +363,7 @@ export class SessionPool extends EventEmitter {
         const persistStateIntervalMillis = serviceLocator.getConfiguration().get('persistStateIntervalMillis')!;
         const timeoutSecs = persistStateIntervalMillis / 2_000;
         await this.keyValueStore
-            .setValue(this.persistStateKey, await this.getState(), {
+            ?.setValue(this.persistStateKey, await this.getState(), {
                 timeoutSecs,
                 doNotRetryTimeouts: true,
             })
@@ -469,7 +468,7 @@ export class SessionPool extends EventEmitter {
      * If the state was persisted it loads the `SessionPool` from the persisted state.
      */
     protected async _maybeLoadSessionPool(): Promise<void> {
-        const loadedSessionPool = await this.keyValueStore.getValue<{ sessions: Dictionary[] }>(this.persistStateKey);
+        const loadedSessionPool = await this.keyValueStore?.getValue<{ sessions: Dictionary[] }>(this.persistStateKey);
 
         if (!loadedSessionPool) return;
 

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -207,12 +207,13 @@ export class SessionPool extends EventEmitter {
     }
 
     private async setupPool(): Promise<void> {
-        this.keyValueStore = await KeyValueStore.open(this.persistStateKeyValueStoreId, {
-            config: serviceLocator.getConfiguration(),
-        });
         if (!this.persistenceOptions.enable) {
             return;
         }
+
+        this.keyValueStore = await KeyValueStore.open(this.persistStateKeyValueStoreId, {
+            config: serviceLocator.getConfiguration(),
+        });
 
         if (!this.persistStateKeyValueStoreId) {
             this.log.debug(

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -183,7 +183,7 @@ export class SessionPool extends EventEmitter {
      * Gets count of usable sessions in the pool.
      */
     async usableSessionsCount(): Promise<number> {
-        await this.initialize();
+        await this.ensureInitialized();
         return this.sessions.filter((session) => session.isUsable()).length;
     }
 
@@ -191,7 +191,7 @@ export class SessionPool extends EventEmitter {
      * Gets count of retired sessions in the pool.
      */
     async retiredSessionsCount(): Promise<number> {
-        await this.initialize();
+        await this.ensureInitialized();
         return this.sessions.filter((session) => !session.isUsable()).length;
     }
 
@@ -199,7 +199,7 @@ export class SessionPool extends EventEmitter {
      * Starts periodic state persistence and potentially loads SessionPool state from {@apilink KeyValueStore}.
      * Called automatically on first use of any public method.
      */
-    async initialize(): Promise<void> {
+    protected async ensureInitialized(): Promise<void> {
         if (!this.initPromise) {
             this.initPromise = this.setupPool();
         }
@@ -235,7 +235,7 @@ export class SessionPool extends EventEmitter {
      * @param [options] The configuration options for the session being added to the session pool.
      */
     async addSession(options: Session | SessionOptions = {}): Promise<void> {
-        await this.initialize();
+        await this.ensureInitialized();
         const { id } = options;
         if (id) {
             const sessionExists = this.sessionMap.has(id);
@@ -262,7 +262,7 @@ export class SessionPool extends EventEmitter {
      * @param [options] The configuration options for the session being added to the session pool.
      */
     async newSession(sessionOptions?: SessionOptions): Promise<Session> {
-        await this.initialize();
+        await this.ensureInitialized();
 
         const newSession = await this.createSessionFunction(this, { sessionOptions });
         this._addSession(newSession);
@@ -291,7 +291,7 @@ export class SessionPool extends EventEmitter {
      * @param [sessionId] If provided, it returns the usable session with this id, `undefined` otherwise.
      */
     async getSession(sessionId?: string): Promise<Session | undefined> {
-        await this.initialize();
+        await this.ensureInitialized();
 
         await this.queue.wait();
         try {
@@ -325,7 +325,7 @@ export class SessionPool extends EventEmitter {
             return;
         }
 
-        await this.initialize();
+        await this.ensureInitialized();
         await this.keyValueStore.setValue(this.persistStateKey, null);
     }
 
@@ -334,7 +334,7 @@ export class SessionPool extends EventEmitter {
      * Note that the object's fields can change in future releases.
      */
     async getState() {
-        await this.initialize();
+        await this.ensureInitialized();
         return {
             usableSessionsCount: await this.usableSessionsCount(),
             retiredSessionsCount: await this.retiredSessionsCount(),
@@ -352,7 +352,7 @@ export class SessionPool extends EventEmitter {
             return;
         }
 
-        await this.initialize();
+        await this.ensureInitialized();
 
         this.log.debug('Persisting state', {
             persistStateKeyValueStoreId: this.persistStateKeyValueStoreId,
@@ -378,7 +378,7 @@ export class SessionPool extends EventEmitter {
      */
     async teardown(): Promise<void> {
         if (!this.initPromise) return;
-        await this.initialize();
+        await this.ensureInitialized();
         this.events.off(EventType.PERSIST_STATE, this._listener);
         await this.persistState();
     }

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1586,6 +1586,7 @@ describe('BasicCrawler', () => {
             await crawler.run();
 
             expect(crawler.sessionPool).toBe(sharedPool);
+            await sharedPool.teardown();
         });
 
         it('should not tear down an injected SessionPool', async () => {
@@ -1607,29 +1608,35 @@ describe('BasicCrawler', () => {
 
         it('should share sessions across crawlers using the same SessionPool', async () => {
             const sharedPool = await SessionPool.open({ maxPoolSize: 5 });
-            const sessionIds = new Set<string>();
+            const crawler1Sessions = new Set<string>();
+            const crawler2Sessions = new Set<string>();
 
             const requestList1 = await RequestList.open({ sources: [{ url: 'https://example.com' }] });
             const crawler1 = new BasicCrawler({
                 requestList: requestList1,
                 sessionPool: sharedPool,
                 requestHandler: async ({ session }) => {
-                    sessionIds.add(session.id);
+                    crawler1Sessions.add(session.id);
                 },
             });
             await crawler1.run();
+
+            expect(crawler1Sessions.size).toBeGreaterThan(0);
+            const poolSizeAfterCrawler1 = sharedPool.usableSessionsCount;
 
             const requestList2 = await RequestList.open({ sources: [{ url: 'https://example.com' }] });
             const crawler2 = new BasicCrawler({
                 requestList: requestList2,
                 sessionPool: sharedPool,
                 requestHandler: async ({ session }) => {
-                    sessionIds.add(session.id);
+                    crawler2Sessions.add(session.id);
                 },
             });
             await crawler2.run();
 
             expect(crawler1.sessionPool).toBe(crawler2.sessionPool);
+            // crawler2 should reuse sessions created by crawler1, not grow the pool further
+            expect(sharedPool.usableSessionsCount).toBe(poolSizeAfterCrawler1);
             await sharedPool.teardown();
         });
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1554,15 +1554,12 @@ describe('BasicCrawler', () => {
                 sessionPoolOptions: {
                     maxPoolSize: 10,
                 },
-                requestHandler: async () => {},
+                requestHandler: async () => {
+                    expect(crawler.sessionPool).toBeDefined();
+                    expect(serviceLocator.getEventManager().listenerCount(EventType.PERSIST_STATE)).toEqual(1);
+                },
                 failedRequestHandler: async () => {},
             });
-
-            // @ts-expect-error Accessing private prop
-            crawler._loadHandledRequestCount = () => {
-                expect(crawler.sessionPool).toBeDefined();
-                expect(serviceLocator.getEventManager().listenerCount(EventType.PERSIST_STATE)).toEqual(1);
-            };
 
             await crawler.run();
             expect(serviceLocator.getEventManager().listenerCount(EventType.PERSIST_STATE)).toEqual(0);

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -15,8 +15,8 @@ import {
     Request,
     RequestList,
     RequestQueue,
-    SessionPool,
     serviceLocator,
+    SessionPool,
 } from '@crawlee/basic';
 import { RequestState } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -15,6 +15,7 @@ import {
     Request,
     RequestList,
     RequestQueue,
+    SessionPool,
     serviceLocator,
 } from '@crawlee/basic';
 import { RequestState } from '@crawlee/core';
@@ -1568,6 +1569,79 @@ describe('BasicCrawler', () => {
             expect(serviceLocator.getEventManager().listenerCount(EventType.PERSIST_STATE)).toEqual(0);
             // @ts-expect-error private symbol
             expect(crawler.sessionPool.maxPoolSize).toEqual(10);
+        });
+
+        it('should accept a pre-initialized SessionPool instance', async () => {
+            const url = 'https://example.com';
+            const requestList = await RequestList.open({ sources: [{ url }] });
+            const sharedPool = await SessionPool.open({ maxPoolSize: 25 });
+
+            const crawler = new BasicCrawler({
+                requestList,
+                sessionPool: sharedPool,
+                requestHandler: async ({ session }) => {
+                    expect(session).toBeDefined();
+                },
+            });
+            await crawler.run();
+
+            expect(crawler.sessionPool).toBe(sharedPool);
+        });
+
+        it('should not tear down an injected SessionPool', async () => {
+            const url = 'https://example.com';
+            const requestList = await RequestList.open({ sources: [{ url }] });
+            const sharedPool = await SessionPool.open({ maxPoolSize: 25 });
+            const teardownSpy = vitest.spyOn(sharedPool, 'teardown');
+
+            const crawler = new BasicCrawler({
+                requestList,
+                sessionPool: sharedPool,
+                requestHandler: async () => {},
+            });
+            await crawler.run();
+
+            expect(teardownSpy).not.toHaveBeenCalled();
+            await sharedPool.teardown();
+        });
+
+        it('should share sessions across crawlers using the same SessionPool', async () => {
+            const sharedPool = await SessionPool.open({ maxPoolSize: 5 });
+            const sessionIds = new Set<string>();
+
+            const requestList1 = await RequestList.open({ sources: [{ url: 'https://example.com' }] });
+            const crawler1 = new BasicCrawler({
+                requestList: requestList1,
+                sessionPool: sharedPool,
+                requestHandler: async ({ session }) => {
+                    sessionIds.add(session.id);
+                },
+            });
+            await crawler1.run();
+
+            const requestList2 = await RequestList.open({ sources: [{ url: 'https://example.com' }] });
+            const crawler2 = new BasicCrawler({
+                requestList: requestList2,
+                sessionPool: sharedPool,
+                requestHandler: async ({ session }) => {
+                    sessionIds.add(session.id);
+                },
+            });
+            await crawler2.run();
+
+            expect(crawler1.sessionPool).toBe(crawler2.sessionPool);
+            await sharedPool.teardown();
+        });
+
+        it('should throw when both sessionPool and sessionPoolOptions are provided', () => {
+            expect(
+                () =>
+                    new BasicCrawler({
+                        sessionPool: new SessionPool(),
+                        sessionPoolOptions: { maxPoolSize: 10 },
+                        requestHandler: async () => {},
+                    }),
+            ).toThrow(/Cannot use both/);
         });
     });
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1504,10 +1504,10 @@ describe('BasicCrawler', () => {
                 requestList,
                 requestHandlerTimeoutSecs: 0.01,
                 maxRequestRetries: 1,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     maxPoolSize: 10,
                     persistStateKey: 'POOL',
-                },
+                }),
                 requestHandler: async ({ session }) => {
                     expect(session.constructor.name).toEqual('Session');
                     expect(session.id).toBeDefined();
@@ -1530,43 +1530,15 @@ describe('BasicCrawler', () => {
                 requestList,
                 requestHandlerTimeoutSecs: 0.01,
                 maxRequestRetries: 1,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     maxPoolSize: 10,
                     persistStateKey: 'POOL',
-                },
+                }),
                 requestHandler: async () => {},
                 failedRequestHandler: async () => {},
             });
             await crawler.run();
 
-            // @ts-expect-error private symbol
-            expect(crawler.sessionPool.maxPoolSize).toEqual(10);
-        });
-
-        it('should destroy Session pool after it is finished', async () => {
-            const url = 'https://example.com';
-            const requestList = await RequestList.open({ sources: [{ url }] });
-            serviceLocator.getEventManager().off(EventType.PERSIST_STATE);
-
-            const crawler = new BasicCrawler({
-                requestList,
-                requestHandlerTimeoutSecs: 0.01,
-                maxRequestRetries: 1,
-                sessionPoolOptions: {
-                    maxPoolSize: 10,
-                },
-                requestHandler: async () => {},
-                failedRequestHandler: async () => {},
-            });
-
-            // @ts-expect-error Accessing private prop
-            crawler._loadHandledRequestCount = () => {
-                expect(crawler.sessionPool).toBeDefined();
-                expect(serviceLocator.getEventManager().listenerCount(EventType.PERSIST_STATE)).toEqual(1);
-            };
-
-            await crawler.run();
-            expect(serviceLocator.getEventManager().listenerCount(EventType.PERSIST_STATE)).toEqual(0);
             // @ts-expect-error private symbol
             expect(crawler.sessionPool.maxPoolSize).toEqual(10);
         });
@@ -1638,17 +1610,6 @@ describe('BasicCrawler', () => {
             // crawler2 should reuse sessions created by crawler1, not grow the pool further
             expect(sharedPool.usableSessionsCount).toBe(poolSizeAfterCrawler1);
             await sharedPool.teardown();
-        });
-
-        it('should throw when both sessionPool and sessionPoolOptions are provided', () => {
-            expect(
-                () =>
-                    new BasicCrawler({
-                        sessionPool: new SessionPool(),
-                        sessionPoolOptions: { maxPoolSize: 10 },
-                        requestHandler: async () => {},
-                    }),
-            ).toThrow(/Cannot use both/);
         });
     });
 

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http';
 
 import { BROWSER_POOL_EVENTS, OperatingSystemsName, PuppeteerPlugin } from '@crawlee/browser-pool';
-import { bindMethodsToServiceLocator, BLOCKED_STATUS_CODES, ServiceLocator } from '@crawlee/core';
+import { bindMethodsToServiceLocator, BLOCKED_STATUS_CODES, ServiceLocator, SessionPool } from '@crawlee/core';
 import type { PuppeteerGoToOptions } from '@crawlee/puppeteer';
 import { EnqueueStrategy, ProxyConfiguration, Request, RequestList, RequestState, Session } from '@crawlee/puppeteer';
 import { sleep } from '@crawlee/utils';
@@ -484,19 +484,19 @@ describe('BrowserCrawler', () => {
                 },
 
                 persistCookiesPerSession: false,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     sessionOptions: {
                         maxUsageCount: 1,
                     },
                     persistStateKeyValueStoreId: 'abc',
-                },
+                }),
                 requestHandler: async () => {},
             });
 
             // @ts-expect-error Accessing private prop
-            expect(crawler.sessionPoolOptions.sessionOptions.maxUsageCount).toBe(1);
+            expect(crawler.sessionPool.sessionOptions.maxUsageCount).toBe(1);
             // @ts-expect-error Accessing private prop
-            expect(crawler.sessionPoolOptions.persistStateKeyValueStoreId).toBe('abc');
+            expect(crawler.sessionPool.persistStateKeyValueStoreId).toBe('abc');
         } finally {
             await localStorageEmulator.destroy();
         }
@@ -803,10 +803,9 @@ describe('BrowserCrawler', () => {
                 browserPoolOptions: {
                     browserPlugins: [puppeteerPlugin],
                 },
-
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     maxPoolSize: 1,
-                },
+                }),
                 requestHandler: async ({ session }) => {
                     sessionUsageHistory.push(session!.usageCount);
                 },
@@ -861,88 +860,6 @@ describe('BrowserCrawler', () => {
     });
 
     describe('proxy', () => {
-        // TODO move to actor sdk tests before splitting the repos
-        // test('browser should launch with correct proxyUrl', async () => {
-        //     process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
-        //     const status = { connected: true };
-        //     const fakeCall = async () => {
-        //         return { body: status } as never;
-        //     };
-        //
-        //     // @ts-expect-error FIXME
-        //     const stub = gotScrapingSpy.mockImplementation(fakeCall);
-        //     const proxyConfiguration = await Actor.createProxyConfiguration();
-        //     const generatedProxyUrl = new URL(await proxyConfiguration.newUrl()).href.slice(0, -1);
-        //     let browserProxy;
-        //
-        //     const browserCrawler = new BrowserCrawlerTest({
-        //         browserPoolOptions: {
-        //             browserPlugins: [puppeteerPlugin],
-        //             postLaunchHooks: [(pageId, browserController) => {
-        //                 browserProxy = browserController.launchContext.proxyUrl;
-        //             }],
-        //         },
-        //         useSessionPool: false,
-        //         persistCookiesPerSession: false,
-        //         navigationTimeoutSecs: 1,
-        //         requestList,
-        //         maxRequestsPerCrawl: 1,
-        //         maxRequestRetries: 0,
-        //         requestHandler: async () => {},
-        //         proxyConfiguration,
-        //     });
-        //     await browserCrawler.run();
-        //     delete process.env[ENV_VARS.PROXY_PASSWORD];
-        //
-        //     expect(browserProxy).toEqual(generatedProxyUrl);
-        //
-        //     stub.mockClear();
-        // });
-
-        // TODO move to actor sdk tests before splitting the repos
-        // test('requestHandler should expose the proxyInfo object with sessions correctly', async () => {
-        //     process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
-        //     const status = { connected: true };
-        //     const fakeCall = async () => {
-        //         return { body: status } as never;
-        //     };
-        //
-        //     // @ts-expect-error FIXME
-        //     const stub = gotScrapingSpy.mockImplementation(fakeCall);
-        //
-        //     const proxyConfiguration = await Actor.createProxyConfiguration();
-        //     const proxies: ProxyInfo[] = [];
-        //     const sessions: Session[] = [];
-        //     const requestHandler = async ({ session, proxyInfo }: BrowserCrawlingContext) => {
-        //         proxies.push(proxyInfo);
-        //         sessions.push(session);
-        //     };
-        //
-        //     const browserCrawler = new BrowserCrawlerTest({
-        //         browserPoolOptions: {
-        //             browserPlugins: [puppeteerPlugin],
-        //         },
-        //         requestList,
-        //         requestHandler,
-        //
-        //         proxyConfiguration,
-        //         useSessionPool: true,
-        //         sessionPoolOptions: {
-        //             maxPoolSize: 1,
-        //         },
-        //     });
-        //
-        //     await browserCrawler.run();
-        //
-        //     expect(proxies[0].sessionId).toEqual(sessions[0].id);
-        //     expect(proxies[1].sessionId).toEqual(sessions[1].id);
-        //     expect(proxies[2].sessionId).toEqual(sessions[2].id);
-        //     expect(proxies[3].sessionId).toEqual(sessions[3].id);
-        //
-        //     delete process.env[ENV_VARS.PROXY_PASSWORD];
-        //     stub.mockClear();
-        // });
-
         // This test manipulates environment variables, so it must NOT be run concurrently
         test('browser should launch with rotated custom proxy', async () => {
             const localStorageEmulator = new MemoryStorageEmulator();

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -11,7 +11,7 @@ import {
     RequestList,
     Session,
 } from '@crawlee/cheerio';
-import { BaseCrawleeLogger } from '@crawlee/core';
+import { BaseCrawleeLogger, SessionPool } from '@crawlee/core';
 import { ImpitHttpClient } from '@crawlee/impit-client';
 import type { ProxyInfo } from '@crawlee/types';
 import type { Dictionary } from '@crawlee/utils';
@@ -869,18 +869,18 @@ describe('CheerioCrawler', () => {
                 requestList,
 
                 persistCookiesPerSession: false,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     sessionOptions: {
                         maxUsageCount: 1,
                     },
                     persistStateKeyValueStoreId: 'abc',
-                },
+                }),
                 requestHandler: () => {},
             });
             // @ts-expect-error Accessing private prop
-            expect(crawler.sessionPoolOptions.sessionOptions.maxUsageCount).toBe(1);
+            expect(crawler.sessionPool.sessionOptions.maxUsageCount).toBe(1);
             // @ts-expect-error Accessing private prop
-            expect(crawler.sessionPoolOptions.persistStateKeyValueStoreId).toBe('abc');
+            expect(crawler.sessionPool.persistStateKeyValueStoreId).toBe('abc');
         });
 
         test('should markBad sessions after request timeout', async () => {
@@ -976,9 +976,9 @@ describe('CheerioCrawler', () => {
                 ),
 
                 persistCookiesPerSession: true,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     maxPoolSize: 1,
-                },
+                }),
                 maxRequestRetries: 1,
                 maxConcurrency: 1,
                 requestHandler: ({ request }) => {
@@ -1007,9 +1007,9 @@ describe('CheerioCrawler', () => {
                 ]),
 
                 persistCookiesPerSession: false,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     maxPoolSize: 1,
-                },
+                }),
                 requestHandler: ({ json }) => {
                     responses.push(json);
                 },
@@ -1037,9 +1037,9 @@ describe('CheerioCrawler', () => {
                 ]),
 
                 persistCookiesPerSession: false,
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     maxPoolSize: 1,
-                },
+                }),
                 requestHandler: ({ json }) => {
                     responses.push(json);
                 },
@@ -1137,10 +1137,10 @@ describe('CheerioCrawler', () => {
             const crawler = new CheerioCrawler({
                 requestList: await RequestList.open(null, [{ url: `${serverAddress}/special/get-cookies` }]),
 
-                sessionPoolOptions: {
+                sessionPool: new SessionPool({
                     // Even with multiple available sessions, the preNavigationHook should use the same one as the main request
                     maxPoolSize: 10,
-                },
+                }),
                 preNavigationHooks: [
                     async ({ sendRequest }) => {
                         await sendRequest({

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -2,7 +2,7 @@ import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { Readable } from 'node:stream';
 
-import { HttpCrawler } from '@crawlee/http';
+import { HttpCrawler, SessionPool } from '@crawlee/http';
 import { ResponseWithUrl } from '@crawlee/http-client';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator.js';
 
@@ -212,9 +212,9 @@ test('handles cookies from redirects', async () => {
     const results: string[] = [];
 
     const crawler = new HttpCrawler({
-        sessionPoolOptions: {
+        sessionPool: new SessionPool({
             maxPoolSize: 1,
-        },
+        }),
         requestHandler: async ({ body }) => {
             results.push(JSON.parse(body.toString()));
         },
@@ -229,9 +229,9 @@ test('handles cookies from redirects - no empty cookie header', async () => {
     const results: string[] = [];
 
     const crawler = new HttpCrawler({
-        sessionPoolOptions: {
+        sessionPool: new SessionPool({
             maxPoolSize: 1,
-        },
+        }),
         requestHandler: async ({ body }) => {
             const str = body.toString();
 
@@ -250,9 +250,9 @@ test('no empty cookie header', async () => {
     const results: string[] = [];
 
     const crawler = new HttpCrawler({
-        sessionPoolOptions: {
+        sessionPool: new SessionPool({
             maxPoolSize: 1,
-        },
+        }),
         requestHandler: async ({ body }) => {
             const str = body.toString();
 

--- a/test/core/crawlers/puppeteer_crawler.test.ts
+++ b/test/core/crawlers/puppeteer_crawler.test.ts
@@ -14,7 +14,14 @@ import type {
     PuppeteerGoToOptions,
     Request,
 } from '@crawlee/puppeteer';
-import { ProxyConfiguration, PuppeteerCrawler, RequestList, RequestQueue, Session } from '@crawlee/puppeteer';
+import {
+    ProxyConfiguration,
+    PuppeteerCrawler,
+    RequestList,
+    RequestQueue,
+    Session,
+    SessionPool,
+} from '@crawlee/puppeteer';
 import type { Cookie } from '@crawlee/types';
 import { sleep } from '@crawlee/utils';
 import type { Server as ProxyChainServer } from 'proxy-chain';
@@ -328,13 +335,13 @@ describe('PuppeteerCrawler', () => {
             requestList,
 
             persistCookiesPerSession: true,
-            sessionPoolOptions: {
+            sessionPool: new SessionPool({
                 createSessionFunction: (sessionPool) => {
                     const session = new Session({ sessionPool });
                     session.setCookies(cookies, serverUrl);
                     return session;
                 },
-            },
+            }),
             requestHandler: async ({ page, session }) => {
                 pageCookies = await page.cookies().then((cks) => cks.map((c) => `${c.name}=${c.value}`).join('; '));
                 sessionCookies = session!.getCookieString(serverUrl);
@@ -361,11 +368,11 @@ describe('PuppeteerCrawler', () => {
                 },
             },
             maxConcurrency: 1,
-            sessionPoolOptions: {
+            sessionPool: new SessionPool({
                 sessionOptions: {
                     maxUsageCount: 1,
                 },
-            },
+            }),
             proxyConfiguration,
             requestHandler: async ({ proxyInfo, session }) => {
                 proxies.add(proxyInfo!.url);

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -8,7 +8,7 @@ describe('SessionPool - testing session pool', () => {
 
     beforeEach(async () => {
         await localStorageEmulator.init();
-        sessionPool = await SessionPool.open();
+        sessionPool = new SessionPool();
     });
 
     afterEach(async () => {
@@ -46,34 +46,6 @@ describe('SessionPool - testing session pool', () => {
             createSessionFunction: () => ({}) as never,
         };
         sessionPool = new SessionPool(opts);
-        await sessionPool.initialize();
-        await sessionPool.teardown();
-
-        entries(opts)
-            .filter(([key]) => key !== 'sessionOptions')
-            .forEach(([key, value]) => {
-                expect(sessionPool[key]).toEqual(value);
-            });
-        // log is appended to sessionOptions after sessionPool instantiation
-        // @ts-expect-error private symbol
-        expect(sessionPool.sessionOptions).toEqual({ ...opts.sessionOptions, log: expect.any(BaseCrawleeLogger) });
-    });
-
-    test('should work using SessionPool.open', async () => {
-        const opts = {
-            maxPoolSize: 3000,
-
-            sessionOptions: {
-                maxAgeSecs: 100,
-                maxUsageCount: 1,
-            },
-
-            persistStateKeyValueStoreId: 'TEST',
-            persistStateKey: 'SESSION_POOL_STATE2',
-
-            createSessionFunction: () => ({}) as never,
-        };
-        sessionPool = await SessionPool.open(opts);
         await sessionPool.teardown();
 
         entries(opts)
@@ -88,7 +60,7 @@ describe('SessionPool - testing session pool', () => {
 
     describe('should retrieve session', () => {
         test('should retrieve session with correct shape', async () => {
-            sessionPool = await SessionPool.open({ sessionOptions: { maxAgeSecs: 100, maxUsageCount: 10 } });
+            sessionPool = new SessionPool({ sessionOptions: { maxAgeSecs: 100, maxUsageCount: 10 } });
             const session = await sessionPool.getSession();
             // @ts-expect-error private symbol
             expect(sessionPool.sessions.length).toBe(1);
@@ -152,7 +124,7 @@ describe('SessionPool - testing session pool', () => {
         const newSession = await sessionPool.getSession();
         newSession.setCookies(cookies, url);
 
-        const state = sessionPool.getState();
+        const state = await sessionPool.getState();
         expect(state).toBeInstanceOf(Object);
         expect(state).toHaveProperty('usableSessionsCount');
         expect(state).toHaveProperty('retiredSessionsCount');
@@ -164,16 +136,14 @@ describe('SessionPool - testing session pool', () => {
         await sessionPool.persistState();
 
         const kvStore = await KeyValueStore.open();
-        const sessionPoolSaved = await kvStore.getValue<ReturnType<SessionPool['getState']>>(
+        const sessionPoolSaved = await kvStore.getValue<Awaited<ReturnType<SessionPool['getState']>>>(
             // @ts-expect-error private symbol
             sessionPool.persistStateKey,
         );
 
-        entries(sessionPoolSaved!).forEach(([key, value]) => {
-            if (key !== 'sessions') {
-                expect(value).toEqual(sessionPool[key]);
-            }
-        });
+        const currentState = await sessionPool.getState();
+        expect(sessionPoolSaved!.usableSessionsCount).toEqual(currentState.usableSessionsCount);
+        expect(sessionPoolSaved!.retiredSessionsCount).toEqual(currentState.retiredSessionsCount);
 
         // @ts-expect-error private symbol
         expect(sessionPoolSaved.sessions.length).toEqual(sessionPool.sessions.length);
@@ -195,7 +165,6 @@ describe('SessionPool - testing session pool', () => {
         });
 
         const loadedSessionPool = new SessionPool();
-
         await loadedSessionPool.initialize();
         // @ts-expect-error private symbol
         expect(sessionPool.sessions).toHaveLength(loadedSessionPool.sessions.length);
@@ -217,6 +186,7 @@ describe('SessionPool - testing session pool', () => {
     });
 
     test('should create session', async () => {
+        await sessionPool.initialize();
         // @ts-expect-error private symbol
         await sessionPool._createSession();
         // @ts-expect-error private symbol
@@ -230,7 +200,6 @@ describe('SessionPool - testing session pool', () => {
 
         beforeEach(async () => {
             sessionPool = new SessionPool({ persistStateKeyValueStoreId: KV_STORE });
-            await sessionPool.initialize();
         });
 
         afterEach(async () => {
@@ -259,7 +228,7 @@ describe('SessionPool - testing session pool', () => {
             // @ts-expect-error private symbol
             const state = await sessionPool.keyValueStore.getValue(sessionPool.persistStateKey);
 
-            expect(sessionPool.getState()).toEqual(state);
+            expect(await sessionPool.getState()).toEqual(state);
         });
     });
 
@@ -291,24 +260,23 @@ describe('SessionPool - testing session pool', () => {
                 invalidSessionsCount += 1;
             }
         }
-        expect(sessionPool.retiredSessionsCount).toEqual(invalidSessionsCount);
+        expect(await sessionPool.retiredSessionsCount()).toEqual(invalidSessionsCount);
 
         await sessionPool.persistState();
 
         const newSessionPool = new SessionPool();
         await newSessionPool.initialize();
-        // @ts-expect-error private symbol
+        // @ts-expect-error Accessing private property
         expect(newSessionPool.sessions).toHaveLength(10 - invalidSessionsCount);
 
         await newSessionPool.teardown();
     });
 
     test('should restore persisted maxUsageCount of recreated sessions', async () => {
-        sessionPool = await SessionPool.open({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 66 } });
+        sessionPool = new SessionPool({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 66 } });
         await sessionPool.getSession();
         await sessionPool.persistState();
         const loadedSessionPool = new SessionPool({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 88 } });
-        await loadedSessionPool.initialize();
 
         const recreatedSession = await loadedSessionPool.getSession();
 
@@ -319,11 +287,12 @@ describe('SessionPool - testing session pool', () => {
         const persistStateKey = 'TEST-KEY';
         const persistStateKeyValueStoreId = 'TEST-VALUE-STORE';
 
-        const newSessionPool = await SessionPool.open({
+        const newSessionPool = new SessionPool({
             maxPoolSize: 1,
             persistStateKeyValueStoreId,
             persistStateKey,
         });
+        await newSessionPool.initialize();
 
         await newSessionPool.teardown();
 
@@ -350,7 +319,7 @@ describe('SessionPool - testing session pool', () => {
             expect(sessionPool2 instanceof SessionPool).toBe(true);
             return new Session({ sessionPool: sessionPool2 });
         };
-        const newSessionPool = await SessionPool.open({ createSessionFunction });
+        const newSessionPool = new SessionPool({ createSessionFunction });
         const session = await newSessionPool.getSession();
         expect(isCalled).toBe(true);
         expect(session.constructor.name).toBe('Session');
@@ -358,6 +327,7 @@ describe('SessionPool - testing session pool', () => {
 
     it('should remove persist state event listener', async () => {
         const events = serviceLocator.getEventManager();
+        await sessionPool.initialize();
         expect(events.listenerCount(EventType.PERSIST_STATE)).toEqual(1);
         await sessionPool.teardown();
         expect(events.listenerCount(EventType.PERSIST_STATE)).toEqual(0);

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -160,6 +160,9 @@ describe('SessionPool - testing session pool', () => {
     });
 
     test('should persist state and recreate it from storage', async () => {
+        const persistStateKey = 'PERSIST_TEST';
+        sessionPool = await SessionPool.open({ persistStateKey });
+
         await sessionPool.getSession();
         await sessionPool.persistState();
 
@@ -194,7 +197,7 @@ describe('SessionPool - testing session pool', () => {
             });
         });
 
-        const loadedSessionPool = new SessionPool();
+        const loadedSessionPool = new SessionPool({ persistStateKey });
 
         await loadedSessionPool.initialize();
         // @ts-expect-error private symbol
@@ -281,6 +284,9 @@ describe('SessionPool - testing session pool', () => {
     });
 
     test('should recreate only usable sessions', async () => {
+        const persistStateKey = 'RECREATE_TEST';
+        sessionPool = await SessionPool.open({ persistStateKey });
+
         let invalidSessionsCount = 0;
         for (let i = 0; i < 10; i++) {
             const session = await sessionPool.getSession();
@@ -295,7 +301,7 @@ describe('SessionPool - testing session pool', () => {
 
         await sessionPool.persistState();
 
-        const newSessionPool = new SessionPool();
+        const newSessionPool = new SessionPool({ persistStateKey });
         await newSessionPool.initialize();
         // @ts-expect-error private symbol
         expect(newSessionPool.sessions).toHaveLength(10 - invalidSessionsCount);
@@ -304,10 +310,19 @@ describe('SessionPool - testing session pool', () => {
     });
 
     test('should restore persisted maxUsageCount of recreated sessions', async () => {
-        sessionPool = await SessionPool.open({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 66 } });
+        const persistStateKey = 'MAX_USAGE_TEST';
+        sessionPool = await SessionPool.open({
+            maxPoolSize: 1,
+            sessionOptions: { maxUsageCount: 66 },
+            persistStateKey,
+        });
         await sessionPool.getSession();
         await sessionPool.persistState();
-        const loadedSessionPool = new SessionPool({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 88 } });
+        const loadedSessionPool = new SessionPool({
+            maxPoolSize: 1,
+            sessionOptions: { maxUsageCount: 88 },
+            persistStateKey,
+        });
         await loadedSessionPool.initialize();
 
         const recreatedSession = await loadedSessionPool.getSession();
@@ -434,5 +449,64 @@ describe('SessionPool - testing session pool', () => {
         expect(sessionPool.sessionMap.size).toEqual(1);
         // @ts-expect-error private symbol
         expect(sessionPool.sessions.length).toEqual(sessionPool.sessionMap.size);
+    });
+
+    describe('multiple SessionPool instances isolation', () => {
+        test('should use unique persist keys by default', async () => {
+            const pool1 = await SessionPool.open();
+            const pool2 = await SessionPool.open();
+
+            // @ts-expect-error private symbol
+            expect(pool1.persistStateKey).not.toEqual(pool2.persistStateKey);
+
+            await pool1.teardown();
+            await pool2.teardown();
+        });
+
+        test("should not overwrite each other's persisted state", async () => {
+            const pool1 = await SessionPool.open({ maxPoolSize: 5 });
+            const pool2 = await SessionPool.open({ maxPoolSize: 5 });
+
+            for (let i = 0; i < 3; i++) await pool1.getSession();
+            for (let i = 0; i < 5; i++) await pool2.getSession();
+
+            await pool1.persistState();
+            await pool2.persistState();
+
+            const pool1Reloaded = await SessionPool.open({
+                // @ts-expect-error private symbol
+                persistStateKey: pool1.persistStateKey,
+            });
+            const pool2Reloaded = await SessionPool.open({
+                // @ts-expect-error private symbol
+                persistStateKey: pool2.persistStateKey,
+            });
+
+            // @ts-expect-error private symbol
+            expect(pool1Reloaded.sessions).toHaveLength(3);
+            // @ts-expect-error private symbol
+            expect(pool2Reloaded.sessions).toHaveLength(5);
+
+            await pool1.teardown();
+            await pool2.teardown();
+            await pool1Reloaded.teardown();
+            await pool2Reloaded.teardown();
+        });
+
+        test('retiring sessions in one pool should not affect another', async () => {
+            const pool1 = await SessionPool.open({ maxPoolSize: 2 });
+            const pool2 = await SessionPool.open({ maxPoolSize: 2 });
+
+            const session1 = await pool1.getSession();
+            await pool2.getSession();
+
+            session1.retire();
+
+            expect(pool1.retiredSessionsCount).toBe(1);
+            expect(pool2.retiredSessionsCount).toBe(0);
+
+            await pool1.teardown();
+            await pool2.teardown();
+        });
     });
 });

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -45,8 +45,7 @@ describe('SessionPool - testing session pool', () => {
 
             createSessionFunction: () => ({}) as never,
         };
-        sessionPool = new SessionPool(opts);
-        await sessionPool.initialize();
+        sessionPool = await SessionPool.open(opts);
         await sessionPool.teardown();
 
         entries(opts)
@@ -194,9 +193,8 @@ describe('SessionPool - testing session pool', () => {
             });
         });
 
-        const loadedSessionPool = new SessionPool();
+        const loadedSessionPool = await SessionPool.open();
 
-        await loadedSessionPool.initialize();
         // @ts-expect-error private symbol
         expect(sessionPool.sessions).toHaveLength(loadedSessionPool.sessions.length);
         // @ts-expect-error private symbol
@@ -229,8 +227,7 @@ describe('SessionPool - testing session pool', () => {
         const KV_STORE = 'SESSION-TEST';
 
         beforeEach(async () => {
-            sessionPool = new SessionPool({ persistStateKeyValueStoreId: KV_STORE });
-            await sessionPool.initialize();
+            sessionPool = await SessionPool.open({ persistStateKeyValueStoreId: KV_STORE });
         });
 
         afterEach(async () => {
@@ -295,8 +292,7 @@ describe('SessionPool - testing session pool', () => {
 
         await sessionPool.persistState();
 
-        const newSessionPool = new SessionPool();
-        await newSessionPool.initialize();
+        const newSessionPool = await SessionPool.open();
         // @ts-expect-error private symbol
         expect(newSessionPool.sessions).toHaveLength(10 - invalidSessionsCount);
 
@@ -307,8 +303,7 @@ describe('SessionPool - testing session pool', () => {
         sessionPool = await SessionPool.open({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 66 } });
         await sessionPool.getSession();
         await sessionPool.persistState();
-        const loadedSessionPool = new SessionPool({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 88 } });
-        await loadedSessionPool.initialize();
+        const loadedSessionPool = await SessionPool.open({ maxPoolSize: 1, sessionOptions: { maxUsageCount: 88 } });
 
         const recreatedSession = await loadedSessionPool.getSession();
 

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -272,7 +272,7 @@ describe('SessionPool - testing session pool', () => {
 
         await sessionPool.persistState();
 
-        const newSessionPool = new SessionPool();
+        const newSessionPool = new SessionPool({ persistStateKey });
         // @ts-expect-error Accessing protected method
         await newSessionPool.ensureInitialized();
         // @ts-expect-error Accessing private property
@@ -457,6 +457,11 @@ describe('SessionPool - testing session pool', () => {
                 persistStateKey: pool2.persistStateKey,
             });
 
+            // @ts-expect-error -- we're reading the private sessions field, public methods initialize the instance automatically
+            await pool1Reloaded.ensureInitialized();
+            // @ts-expect-error
+            await pool2Reloaded.ensureInitialized();
+
             // @ts-expect-error private symbol
             expect(pool1Reloaded.sessions).toHaveLength(3);
             // @ts-expect-error private symbol
@@ -477,8 +482,8 @@ describe('SessionPool - testing session pool', () => {
 
             session1.retire();
 
-            expect(pool1.retiredSessionsCount).toBe(1);
-            expect(pool2.retiredSessionsCount).toBe(0);
+            expect(await pool1.retiredSessionsCount()).toBe(1);
+            expect(await pool2.retiredSessionsCount()).toBe(0);
 
             await pool1.teardown();
             await pool2.teardown();

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -165,7 +165,8 @@ describe('SessionPool - testing session pool', () => {
         });
 
         const loadedSessionPool = new SessionPool();
-        await loadedSessionPool.initialize();
+        // @ts-expect-error Accessing protected method
+        await loadedSessionPool.ensureInitialized();
         // @ts-expect-error private symbol
         expect(sessionPool.sessions).toHaveLength(loadedSessionPool.sessions.length);
         // @ts-expect-error private symbol
@@ -186,7 +187,8 @@ describe('SessionPool - testing session pool', () => {
     });
 
     test('should create session', async () => {
-        await sessionPool.initialize();
+        // @ts-expect-error Accessing protected method
+        await sessionPool.ensureInitialized();
         // @ts-expect-error private symbol
         await sessionPool._createSession();
         // @ts-expect-error private symbol
@@ -265,7 +267,8 @@ describe('SessionPool - testing session pool', () => {
         await sessionPool.persistState();
 
         const newSessionPool = new SessionPool();
-        await newSessionPool.initialize();
+        // @ts-expect-error Accessing protected method
+        await newSessionPool.ensureInitialized();
         // @ts-expect-error Accessing private property
         expect(newSessionPool.sessions).toHaveLength(10 - invalidSessionsCount);
 
@@ -292,7 +295,8 @@ describe('SessionPool - testing session pool', () => {
             persistStateKeyValueStoreId,
             persistStateKey,
         });
-        await newSessionPool.initialize();
+        // @ts-expect-error Accessing protected method
+        await newSessionPool.ensureInitialized();
 
         await newSessionPool.teardown();
 
@@ -327,7 +331,8 @@ describe('SessionPool - testing session pool', () => {
 
     it('should remove persist state event listener', async () => {
         const events = serviceLocator.getEventManager();
-        await sessionPool.initialize();
+        // @ts-expect-error Accessing protected method
+        await sessionPool.ensureInitialized();
         expect(events.listenerCount(EventType.PERSIST_STATE)).toEqual(1);
         await sessionPool.teardown();
         expect(events.listenerCount(EventType.PERSIST_STATE)).toEqual(0);


### PR DESCRIPTION
`BasicCrawler` and subclasses now accept `sessionPool` option for passing a pre-initialized `SessionPool` instance. This is mutually exclusive with `sessionPoolOptions`. 

`SessionPool` instances now do not share the persistence keys (similar to e.g. `Statistics`).

Closes #3445 