### PR TITLE
docs: add CloakBrowser to avoid-blocking guide

### DIFF
--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -13,6 +13,7 @@ import PuppeteerSource from '!!raw-loader!./avoid_blocking_puppeteer';
 import PlaywrightFingerprintsOffSource from '!!raw-loader!./avoid_blocking_playwright_fingerprints_off.ts';
 import PuppeteerFingerprintsOffSource from '!!raw-loader!./avoid_blocking_puppeteer_fingerprints_off.ts';
 import PlaywrightCamoufox from '!!raw-loader!./avoid_blocking_camoufox.ts';
+import PlaywrightCloakBrowser from '!!raw-loader!./avoid_blocking_cloakbrowser.ts';
 
 A scraper might get blocked for numerous reasons. Let's narrow it down to the two main ones. The first is a bad or blocked IP address. You can learn about this topic in the [proxy management guide](./proxy-management). The second reason is [browser fingerprints](https://pixelprivacy.com/resources/browser-fingerprinting/) (or signatures), which we will explore more in this guide. Check the [Apify Academy anti-scraping course](https://docs.apify.com/academy/anti-scraping) to gain a deeper theoretical understanding of blocking and learn a few tips and tricks.
 
@@ -62,6 +63,14 @@ For some protections, using our integrated solutions is not enough, one example 
 
 <CodeBlock language="ts">
     {PlaywrightCamoufox}
+</CodeBlock>
+
+## CloakBrowser
+
+For sites with aggressive anti-bot protection, [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) takes a different approach. Instead of overriding fingerprints at the JavaScript level (which anti-bot scripts can detect as tampering), CloakBrowser ships a custom Chromium binary with fingerprints modified directly in the C++ source code. It is also Chromium-based, which can matter when a target site behaves differently with Firefox than with Chrome. Install it separately with `npm install cloakbrowser` — the binary auto-downloads on first run.
+
+<CodeBlock language="ts">
+    {PlaywrightCloakBrowser}
 </CodeBlock>
 
 **Related links**

--- a/docs/guides/avoid_blocking_cloakbrowser.ts
+++ b/docs/guides/avoid_blocking_cloakbrowser.ts
@@ -1,0 +1,23 @@
+import { PlaywrightCrawler } from 'crawlee';
+import { ensureBinary, getDefaultStealthArgs } from 'cloakbrowser';
+import { chromium } from 'playwright';
+
+// CloakBrowser is a stealth Chromium binary with source-level C++ fingerprint patches.
+// Install: npm install cloakbrowser (binary auto-downloads on first run)
+const executablePath = await ensureBinary();
+const stealthArgs = getDefaultStealthArgs();
+
+const crawler = new PlaywrightCrawler({
+    browserPoolOptions: {
+        // Disable the default fingerprint spoofing to avoid conflicts with CloakBrowser.
+        useFingerprints: false,
+    },
+    launchContext: {
+        launcher: chromium,
+        launchOptions: {
+            executablePath,
+            args: stealthArgs,
+        },
+    },
+    // ...
+});


### PR DESCRIPTION
## Summary

Add CloakBrowser as a stealth browser option in the "Avoid getting blocked" guide, alongside Camoufox. This mirrors the same change already merged in [crawlee-python#1794](https://github.com/apify/crawlee-python/pull/1794).

[CloakBrowser](https://github.com/CloakHQ/CloakBrowser) ships a custom Chromium binary with fingerprints modified at the C++ source level, rather than through JavaScript injection. Chromium-based, which can matter when a target site behaves differently with Firefox.

## Changes

- `docs/guides/avoid_blocking_cloakbrowser.ts` — Code snippet showing `PlaywrightCrawler` with CloakBrowser's binary via `launchContext`
- `docs/guides/avoid_blocking.mdx` — Import + new "CloakBrowser" section after Camoufox

## Testing

Tested with Crawlee 3.x on headless Linux. CloakBrowser launches via `launchContext`, crawler processes requests successfully. Bot detection (bot.sannysoft.com) returns 57/57 tests passed.