### PR TITLE
feat(utils): add sitemapFilter option to parseSitemap

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -200,7 +200,7 @@ export interface ParseSitemapOptions {
      * Return `true` to include the sitemap, `false` to skip it.
      * If not provided, all nested sitemaps are followed.
      */
-    sitemapFilter?: (sitemapUrl: string) => boolean;
+    nestedSitemapFilter?: (sitemapUrl: string) => boolean;
 }
 
 export async function* parseSitemap<T extends ParseSitemapOptions>(
@@ -216,7 +216,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
         sitemapRetries = 3,
         networkTimeouts,
         reportNetworkErrors = true,
-        sitemapFilter,
+        nestedSitemapFilter,
     } = options ?? {};
 
     const sources = [...initialSources];
@@ -348,8 +348,8 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
 
         for await (const item of items) {
             if (item.type === 'sitemapUrl' && !visitedSitemapUrls.has(item.url)) {
-                if (sitemapFilter && !sitemapFilter(item.url)) {
-                    log.debug(`Skipping sitemap ${item.url} due to sitemapFilter.`);
+                if (nestedSitemapFilter && !nestedSitemapFilter(item.url)) {
+                    log.debug(`Skipping sitemap ${item.url} due to nestedSitemapFilter.`);
                     continue;
                 }
 

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -194,6 +194,13 @@ export interface ParseSitemapOptions {
      * @default true
      */
     reportNetworkErrors?: boolean;
+    /**
+     * Optional filter for nested sitemap URLs discovered in sitemap index files.
+     * Called with the URL of each child sitemap before it is fetched.
+     * Return `true` to include the sitemap, `false` to skip it.
+     * If not provided, all nested sitemaps are followed.
+     */
+    sitemapFilter?: (sitemapUrl: string) => boolean;
 }
 
 export async function* parseSitemap<T extends ParseSitemapOptions>(
@@ -209,6 +216,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
         sitemapRetries = 3,
         networkTimeouts,
         reportNetworkErrors = true,
+        sitemapFilter,
     } = options ?? {};
 
     const sources = [...initialSources];
@@ -340,6 +348,11 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
 
         for await (const item of items) {
             if (item.type === 'sitemapUrl' && !visitedSitemapUrls.has(item.url)) {
+                if (sitemapFilter && !sitemapFilter(item.url)) {
+                    log.debug(`Skipping sitemap ${item.url} due to sitemapFilter.`);
+                    continue;
+                }
+
                 sources.push({ type: 'url', url: item.url, depth: (source.depth ?? 0) + 1 });
                 if (emitNestedSitemaps) {
                     yield { loc: item.url, originSitemapUrl: null } as any;

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -294,6 +294,33 @@ describe('Sitemap', () => {
         );
     });
 
+    it('respects sitemapFilter when following sitemap indexes', async () => {
+        const items: SitemapUrl[] = [];
+
+        for await (const item of parseSitemap(
+            [{ type: 'url', url: 'http://not-exists.com/sitemap_parent.xml' }],
+            undefined,
+            {
+                sitemapFilter: (url) => !url.includes('sitemap_child_2'),
+            },
+        )) {
+            items.push(item);
+        }
+
+        expect(items).toHaveLength(5);
+        expect(items.every((item) => item.originSitemapUrl === 'http://not-exists.com/sitemap_child.xml')).toBe(true);
+    });
+
+    it('follows all nested sitemaps when sitemapFilter is not provided', async () => {
+        const items: SitemapUrl[] = [];
+
+        for await (const item of parseSitemap([{ type: 'url', url: 'http://not-exists.com/sitemap_parent.xml' }])) {
+            items.push(item);
+        }
+
+        expect(items).toHaveLength(10);
+    });
+
     it('does not break on invalid xml', async () => {
         const sitemap = await Sitemap.load('http://not-exists.com/not_actual_xml.xml');
         expect(sitemap.urls).toEqual([]);

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -294,14 +294,14 @@ describe('Sitemap', () => {
         );
     });
 
-    it('respects sitemapFilter when following sitemap indexes', async () => {
+    it('respects nestedSitemapFilter when following sitemap indexes', async () => {
         const items: SitemapUrl[] = [];
 
         for await (const item of parseSitemap(
             [{ type: 'url', url: 'http://not-exists.com/sitemap_parent.xml' }],
             undefined,
             {
-                sitemapFilter: (url) => !url.includes('sitemap_child_2'),
+                nestedSitemapFilter: (url) => !url.includes('sitemap_child_2'),
             },
         )) {
             items.push(item);
@@ -311,7 +311,7 @@ describe('Sitemap', () => {
         expect(items.every((item) => item.originSitemapUrl === 'http://not-exists.com/sitemap_child.xml')).toBe(true);
     });
 
-    it('follows all nested sitemaps when sitemapFilter is not provided', async () => {
+    it('follows all nested sitemaps when nestedSitemapFilter is not provided', async () => {
         const items: SitemapUrl[] = [];
 
         for await (const item of parseSitemap([{ type: 'url', url: 'http://not-exists.com/sitemap_parent.xml' }])) {


### PR DESCRIPTION
## Motivation
When working with sitemap index files, `parseSitemap` currently follows all child sitemaps unconditionally. Sometimes sitemap indexes contain hundreds of child sitemaps, for instance, a child sitemap for every month going back 15 years (e.g., `/articles-2010-01.xml` through `/articles-2026-03.xml`). If you're only interested in the last 2 years of content, there's no way to skip the irrelevant ones without fetching and parsing all of them.

This PR adds a `sitemapFilter` callback option that lets you control which child sitemaps to skip, based on their URL.

## Changes
- Add optional `sitemapFilter?: (sitemapUrl: string) => boolean` to `ParseSitemapOptions`
- When provided, each child sitemap URL discovered in a sitemap index is passed through the filter before being fetched. Return `true` to include, `false` to skip.
- When not provided, behavior is unchanged all nested sitemaps are followed.
- Skipped sitemaps are logged at debug level.

## Example usage
```typescript
// Only follow child sitemaps from the last 2 years
for await (const url of parseSitemap(sources, undefined, {
    sitemapFilter: (url) => /articles-202[4-5]/.test(url),
})) {
    // ...
}