### PR TITLE
feat: Parallel sitemap discovery

### DIFF
--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -114,7 +114,7 @@ export interface SitemapRequestListOptions extends UrlConstraints {
 
 interface SitemapParsingProgress {
     inProgressSitemapUrls: Set<string>;
-    inProgressEntries: Set<string>;
+    inProgressEntriesPerSitemap: Map<string, Set<string>>;
     pendingSitemapUrls: Set<string>;
 }
 
@@ -124,8 +124,9 @@ interface SitemapRequestListState {
     sitemapParsingProgress: {
         pendingSitemapUrls: string[];
         inProgressSitemapUrls?: string[];
-        inProgressSitemapUrl?: string | null; // Backward compatibility with old state format
-        inProgressEntries: string[];
+        inProgressSitemapUrl?: string | null;
+        inProgressEntries?: string[];
+        inProgressEntriesPerSitemap?: Record<string, string[]>;
     };
     abortLoading: boolean;
     closed: boolean;
@@ -158,17 +159,8 @@ export class SitemapRequestList implements IRequestList {
      * Object for keeping track of the sitemap parsing progress.
      */
     private sitemapParsingProgress: SitemapParsingProgress = {
-        /**
-         * Set of sitemap URLs that are currently being parsed.
-         */
         inProgressSitemapUrls: new Set<string>(),
-        /**
-         * Buffer for URLs from the currently parsed sitemaps. Used for tracking partially loaded sitemaps across migrations.
-         */
-        inProgressEntries: new Set<string>(),
-        /**
-         * Set of sitemap URLs that have not been parsed yet. If the set is empty and `inProgressSitemapUrls` is empty, the sitemap loading is finished.
-         */
+        inProgressEntriesPerSitemap: new Map<string, Set<string>>(),
         pendingSitemapUrls: new Set<string>(),
     };
 
@@ -382,6 +374,15 @@ export class SitemapRequestList implements IRequestList {
         );
     }
 
+    private isUrlAlreadyEmitted(url: string): boolean {
+        for (const entries of this.sitemapParsingProgress.inProgressEntriesPerSitemap.values()) {
+            if (entries.has(url)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Processes a single sitemap URL and emits its URLs to the queue.
      * Nested sitemaps are added to the pending queue for later processing.
@@ -392,30 +393,32 @@ export class SitemapRequestList implements IRequestList {
     ): Promise<void> {
         this.sitemapParsingProgress.inProgressSitemapUrls.add(sitemapUrl);
 
+        if (!this.sitemapParsingProgress.inProgressEntriesPerSitemap.has(sitemapUrl)) {
+            this.sitemapParsingProgress.inProgressEntriesPerSitemap.set(sitemapUrl, new Set<string>());
+        }
+        const entries = this.sitemapParsingProgress.inProgressEntriesPerSitemap.get(sitemapUrl)!;
+
         try {
             for await (const item of parseSitemap([{ type: 'url', url: sitemapUrl }], this.proxyUrl, {
                 ...parseSitemapOptions,
                 maxDepth: 0,
                 emitNestedSitemaps: true,
             })) {
-                if (this.abortLoading) {
-                    break;
-                }
+                if (this.abortLoading) break;
 
                 if (!item.originSitemapUrl) {
-                    // This is a nested sitemap - add to pending if not already processed or in progress
                     if (
                         !this.sitemapParsingProgress.inProgressSitemapUrls.has(item.loc) &&
-                        !this.sitemapParsingProgress.inProgressEntries.has(item.loc)
+                        !this.sitemapParsingProgress.pendingSitemapUrls.has(item.loc)
                     ) {
                         this.sitemapParsingProgress.pendingSitemapUrls.add(item.loc);
                     }
                     continue;
                 }
 
-                if (!this.sitemapParsingProgress.inProgressEntries.has(item.loc)) {
+                if (!entries.has(item.loc) && !this.isUrlAlreadyEmitted(item.loc)) {
                     await this.pushNextUrl(item.loc);
-                    this.sitemapParsingProgress.inProgressEntries.add(item.loc);
+                    entries.add(item.loc);
                 }
             }
         } catch (e: any) {
@@ -423,6 +426,7 @@ export class SitemapRequestList implements IRequestList {
         } finally {
             this.sitemapParsingProgress.inProgressSitemapUrls.delete(sitemapUrl);
             this.sitemapParsingProgress.pendingSitemapUrls.delete(sitemapUrl);
+            this.sitemapParsingProgress.inProgressEntriesPerSitemap.delete(sitemapUrl);
         }
     }
 
@@ -449,35 +453,23 @@ export class SitemapRequestList implements IRequestList {
 
                 const loaderPromise = this.loadSingleSitemap(sitemapUrl, parseSitemapOptions).finally(() => {
                     const index = activeLoaders.indexOf(loaderPromise);
-                    if (index !== -1) {
-                        activeLoaders.splice(index, 1);
-                    }
+                    if (index !== -1) void activeLoaders.splice(index, 1);
                 });
-
                 activeLoaders.push(loaderPromise);
             }
         };
 
-        // Start initial batch of loaders
         startNewLoaders();
 
-        // Keep loading until all sitemaps are processed
         while (
             (activeLoaders.length > 0 || this.sitemapParsingProgress.pendingSitemapUrls.size > 0) &&
             !this.abortLoading
         ) {
-            if (activeLoaders.length > 0) {
-                // Wait for at least one loader to complete
-                await Promise.race(activeLoaders);
-            }
-            // Start new loaders if slots are available
+            if (activeLoaders.length > 0) await Promise.race(activeLoaders);
             startNewLoaders();
         }
 
-        // Wait for any remaining active loaders to complete
-        if (activeLoaders.length > 0) {
-            await Promise.all(activeLoaders);
-        }
+        if (activeLoaders.length > 0) await Promise.all(activeLoaders);
 
         this.urlQueueStream.end();
     }
@@ -578,11 +570,16 @@ export class SitemapRequestList implements IRequestList {
 
         this.urlQueueStream = newStream;
 
+        const inProgressEntriesPerSitemap: Record<string, string[]> = {};
+        for (const [sitemapUrl, entries] of this.sitemapParsingProgress.inProgressEntriesPerSitemap) {
+            inProgressEntriesPerSitemap[sitemapUrl] = Array.from(entries);
+        }
+
         await this.store.setValue(this.persistStateKey, {
             sitemapParsingProgress: {
                 pendingSitemapUrls: Array.from(this.sitemapParsingProgress.pendingSitemapUrls),
                 inProgressSitemapUrls: Array.from(this.sitemapParsingProgress.inProgressSitemapUrls),
-                inProgressEntries: Array.from(this.sitemapParsingProgress.inProgressEntries),
+                inProgressEntriesPerSitemap,
             },
             urlQueue,
             reclaimed: [...this.inProgress, ...this.reclaimed], // In-progress and reclaimed requests will be both retried if state is restored
@@ -608,24 +605,32 @@ export class SitemapRequestList implements IRequestList {
 
         this.reclaimed = new Set(state.reclaimed);
 
-        // Handle backward compatibility: old state had inProgressSitemapUrl (string | null),
-        // new state has inProgressSitemapUrls (array)
         const inProgressSitemapUrls = state.sitemapParsingProgress.inProgressSitemapUrls
             ? new Set<string>(state.sitemapParsingProgress.inProgressSitemapUrls)
             : new Set<string>();
 
-        // Backward compatibility: if old state had inProgressSitemapUrl, add it to pending for retry
+        // Backward compat: old state had single inProgressSitemapUrl
         if (state.sitemapParsingProgress.inProgressSitemapUrl && !state.sitemapParsingProgress.inProgressSitemapUrls) {
             inProgressSitemapUrls.add(state.sitemapParsingProgress.inProgressSitemapUrl);
         }
 
+        const inProgressEntriesPerSitemap = new Map<string, Set<string>>();
+        if (state.sitemapParsingProgress.inProgressEntriesPerSitemap) {
+            for (const [sitemapUrl, entries] of Object.entries(
+                state.sitemapParsingProgress.inProgressEntriesPerSitemap,
+            )) {
+                inProgressEntriesPerSitemap.set(sitemapUrl, new Set(entries));
+            }
+        } else if (state.sitemapParsingProgress.inProgressEntries && inProgressSitemapUrls.size > 0) {
+            // Backward compat: old format had flat inProgressEntries
+            const firstSitemapUrl = inProgressSitemapUrls.values().next().value!;
+            inProgressEntriesPerSitemap.set(firstSitemapUrl, new Set(state.sitemapParsingProgress.inProgressEntries));
+        }
+
         this.sitemapParsingProgress = {
-            pendingSitemapUrls: new Set([
-                ...state.sitemapParsingProgress.pendingSitemapUrls,
-                ...inProgressSitemapUrls, // Re-add in-progress sitemaps to pending for retry on restore
-            ]),
+            pendingSitemapUrls: new Set([...state.sitemapParsingProgress.pendingSitemapUrls, ...inProgressSitemapUrls]),
             inProgressSitemapUrls: new Set<string>(),
-            inProgressEntries: new Set(state.sitemapParsingProgress.inProgressEntries),
+            inProgressEntriesPerSitemap,
         };
 
         this.requestData = new Map(state.requestData ?? []);

--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -103,10 +103,17 @@ export interface SitemapRequestListOptions extends UrlConstraints {
      * Crawlee configuration
      */
     config?: Configuration;
+    /**
+     * Maximum number of sitemaps to load in parallel.
+     * This includes both the initial sitemaps and any nested sitemaps discovered during parsing.
+     *
+     * @default 1
+     */
+    concurrency?: number;
 }
 
 interface SitemapParsingProgress {
-    inProgressSitemapUrl: string | null;
+    inProgressSitemapUrls: Set<string>;
     inProgressEntries: Set<string>;
     pendingSitemapUrls: Set<string>;
 }
@@ -114,7 +121,12 @@ interface SitemapParsingProgress {
 interface SitemapRequestListState {
     urlQueue: string[];
     reclaimed: string[];
-    sitemapParsingProgress: Record<keyof SitemapParsingProgress, any>;
+    sitemapParsingProgress: {
+        pendingSitemapUrls: string[];
+        inProgressSitemapUrls?: string[];
+        inProgressSitemapUrl?: string | null; // Backward compatibility with old state format
+        inProgressEntries: string[];
+    };
     abortLoading: boolean;
     closed: boolean;
     requestData: [string, Request][];
@@ -147,18 +159,23 @@ export class SitemapRequestList implements IRequestList {
      */
     private sitemapParsingProgress: SitemapParsingProgress = {
         /**
-         * URL of the sitemap that is currently being parsed. `null` if no sitemap is being parsed.
+         * Set of sitemap URLs that are currently being parsed.
          */
-        inProgressSitemapUrl: null,
+        inProgressSitemapUrls: new Set<string>(),
         /**
-         * Buffer for URLs from the currently parsed sitemap. Used for tracking partially loaded sitemaps across migrations.
+         * Buffer for URLs from the currently parsed sitemaps. Used for tracking partially loaded sitemaps across migrations.
          */
         inProgressEntries: new Set<string>(),
         /**
-         * Set of sitemap URLs that have not been parsed yet. If the set is empty and `inProgressSitemapUrl` is `null`, the sitemap loading is finished.
+         * Set of sitemap URLs that have not been parsed yet. If the set is empty and `inProgressSitemapUrls` is empty, the sitemap loading is finished.
          */
         pendingSitemapUrls: new Set<string>(),
     };
+
+    /**
+     * Maximum number of sitemaps to load in parallel.
+     */
+    private concurrency: number;
 
     /**
      * Object stream of URLs parsed from the sitemaps.
@@ -224,10 +241,13 @@ export class SitemapRequestList implements IRequestList {
                 regexps: ow.optional.array.ofType(ow.any(ow.regExp, ow.object.hasKeys('regexp'))),
                 config: ow.optional.object,
                 persistenceOptions: ow.optional.object,
+                concurrency: ow.optional.number.integer.greaterThanOrEqual(1),
             }),
         );
 
-        const { globs, exclude, regexps, config = Configuration.getGlobalConfig() } = options;
+        const { globs, exclude, regexps, config = Configuration.getGlobalConfig(), concurrency = 1 } = options;
+
+        this.concurrency = concurrency;
 
         if (exclude?.length) {
             for (const excl of exclude) {
@@ -357,9 +377,53 @@ export class SitemapRequestList implements IRequestList {
      */
     isSitemapFullyLoaded(): boolean {
         return (
-            this.sitemapParsingProgress.inProgressSitemapUrl === null &&
+            this.sitemapParsingProgress.inProgressSitemapUrls.size === 0 &&
             this.sitemapParsingProgress.pendingSitemapUrls.size === 0
         );
+    }
+
+    /**
+     * Processes a single sitemap URL and emits its URLs to the queue.
+     * Nested sitemaps are added to the pending queue for later processing.
+     */
+    private async loadSingleSitemap(
+        sitemapUrl: string,
+        parseSitemapOptions?: SitemapRequestListOptions['parseSitemapOptions'],
+    ): Promise<void> {
+        this.sitemapParsingProgress.inProgressSitemapUrls.add(sitemapUrl);
+
+        try {
+            for await (const item of parseSitemap([{ type: 'url', url: sitemapUrl }], this.proxyUrl, {
+                ...parseSitemapOptions,
+                maxDepth: 0,
+                emitNestedSitemaps: true,
+            })) {
+                if (this.abortLoading) {
+                    break;
+                }
+
+                if (!item.originSitemapUrl) {
+                    // This is a nested sitemap - add to pending if not already processed or in progress
+                    if (
+                        !this.sitemapParsingProgress.inProgressSitemapUrls.has(item.loc) &&
+                        !this.sitemapParsingProgress.inProgressEntries.has(item.loc)
+                    ) {
+                        this.sitemapParsingProgress.pendingSitemapUrls.add(item.loc);
+                    }
+                    continue;
+                }
+
+                if (!this.sitemapParsingProgress.inProgressEntries.has(item.loc)) {
+                    await this.pushNextUrl(item.loc);
+                    this.sitemapParsingProgress.inProgressEntries.add(item.loc);
+                }
+            }
+        } catch (e: any) {
+            this.log.error(`Error loading sitemap contents from ${sitemapUrl}:`, e);
+        } finally {
+            this.sitemapParsingProgress.inProgressSitemapUrls.delete(sitemapUrl);
+            this.sitemapParsingProgress.pendingSitemapUrls.delete(sitemapUrl);
+        }
     }
 
     /**
@@ -372,35 +436,47 @@ export class SitemapRequestList implements IRequestList {
     }: {
         parseSitemapOptions?: SitemapRequestListOptions['parseSitemapOptions'];
     }): Promise<void> {
-        while (!this.isSitemapFullyLoaded() && !this.abortLoading) {
-            const sitemapUrl =
-                this.sitemapParsingProgress.inProgressSitemapUrl ??
-                this.sitemapParsingProgress.pendingSitemapUrls.values().next().value!;
+        const activeLoaders: Promise<void>[] = [];
 
-            try {
-                for await (const item of parseSitemap([{ type: 'url', url: sitemapUrl }], this.proxyUrl, {
-                    ...parseSitemapOptions,
-                    maxDepth: 0,
-                    emitNestedSitemaps: true,
-                })) {
-                    if (!item.originSitemapUrl) {
-                        // This is a nested sitemap
-                        this.sitemapParsingProgress.pendingSitemapUrls.add(item.loc);
-                        continue;
-                    }
+        const startNewLoaders = () => {
+            while (
+                !this.abortLoading &&
+                activeLoaders.length < this.concurrency &&
+                this.sitemapParsingProgress.pendingSitemapUrls.size > 0
+            ) {
+                const sitemapUrl = this.sitemapParsingProgress.pendingSitemapUrls.values().next().value!;
+                this.sitemapParsingProgress.pendingSitemapUrls.delete(sitemapUrl);
 
-                    if (!this.sitemapParsingProgress.inProgressEntries.has(item.loc)) {
-                        await this.pushNextUrl(item.loc);
-                        this.sitemapParsingProgress.inProgressEntries.add(item.loc);
+                const loaderPromise = this.loadSingleSitemap(sitemapUrl, parseSitemapOptions).finally(() => {
+                    const index = activeLoaders.indexOf(loaderPromise);
+                    if (index !== -1) {
+                        activeLoaders.splice(index, 1);
                     }
-                }
-            } catch (e: any) {
-                this.log.error('Error loading sitemap contents:', e);
+                });
+
+                activeLoaders.push(loaderPromise);
             }
+        };
 
-            this.sitemapParsingProgress.pendingSitemapUrls.delete(sitemapUrl);
-            this.sitemapParsingProgress.inProgressEntries.clear();
-            this.sitemapParsingProgress.inProgressSitemapUrl = null;
+        // Start initial batch of loaders
+        startNewLoaders();
+
+        // Keep loading until all sitemaps are processed
+        while (
+            (activeLoaders.length > 0 || this.sitemapParsingProgress.pendingSitemapUrls.size > 0) &&
+            !this.abortLoading
+        ) {
+            if (activeLoaders.length > 0) {
+                // Wait for at least one loader to complete
+                await Promise.race(activeLoaders);
+            }
+            // Start new loaders if slots are available
+            startNewLoaders();
+        }
+
+        // Wait for any remaining active loaders to complete
+        if (activeLoaders.length > 0) {
+            await Promise.all(activeLoaders);
         }
 
         this.urlQueueStream.end();
@@ -505,7 +581,7 @@ export class SitemapRequestList implements IRequestList {
         await this.store.setValue(this.persistStateKey, {
             sitemapParsingProgress: {
                 pendingSitemapUrls: Array.from(this.sitemapParsingProgress.pendingSitemapUrls),
-                inProgressSitemapUrl: this.sitemapParsingProgress.inProgressSitemapUrl,
+                inProgressSitemapUrls: Array.from(this.sitemapParsingProgress.inProgressSitemapUrls),
                 inProgressEntries: Array.from(this.sitemapParsingProgress.inProgressEntries),
             },
             urlQueue,
@@ -531,9 +607,24 @@ export class SitemapRequestList implements IRequestList {
         }
 
         this.reclaimed = new Set(state.reclaimed);
+
+        // Handle backward compatibility: old state had inProgressSitemapUrl (string | null),
+        // new state has inProgressSitemapUrls (array)
+        const inProgressSitemapUrls = state.sitemapParsingProgress.inProgressSitemapUrls
+            ? new Set<string>(state.sitemapParsingProgress.inProgressSitemapUrls)
+            : new Set<string>();
+
+        // Backward compatibility: if old state had inProgressSitemapUrl, add it to pending for retry
+        if (state.sitemapParsingProgress.inProgressSitemapUrl && !state.sitemapParsingProgress.inProgressSitemapUrls) {
+            inProgressSitemapUrls.add(state.sitemapParsingProgress.inProgressSitemapUrl);
+        }
+
         this.sitemapParsingProgress = {
-            pendingSitemapUrls: new Set(state.sitemapParsingProgress.pendingSitemapUrls),
-            inProgressSitemapUrl: state.sitemapParsingProgress.inProgressSitemapUrl,
+            pendingSitemapUrls: new Set([
+                ...state.sitemapParsingProgress.pendingSitemapUrls,
+                ...inProgressSitemapUrls, // Re-add in-progress sitemaps to pending for retry on restore
+            ]),
+            inProgressSitemapUrls: new Set<string>(),
             inProgressEntries: new Set(state.sitemapParsingProgress.inProgressEntries),
         };
 

--- a/test/core/sitemap_request_list.test.ts
+++ b/test/core/sitemap_request_list.test.ts
@@ -193,6 +193,90 @@ beforeAll(async () => {
 
         res.end();
     });
+
+    // Sitemaps for concurrency testing
+    const concurrencyLoadTimes: Record<string, number> = {};
+
+    app.get('/sitemap-slow-1.xml', async (req, res) => {
+        concurrencyLoadTimes['slow-1-start'] = Date.now();
+        res.setHeader('content-type', 'text/xml');
+        await sleep(100);
+        res.write(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                '<url><loc>http://not-exists.com/slow-1-page-1</loc></url>',
+                '<url><loc>http://not-exists.com/slow-1-page-2</loc></url>',
+                '</urlset>',
+            ].join('\n'),
+        );
+        concurrencyLoadTimes['slow-1-end'] = Date.now();
+        res.end();
+    });
+
+    app.get('/sitemap-slow-2.xml', async (req, res) => {
+        concurrencyLoadTimes['slow-2-start'] = Date.now();
+        res.setHeader('content-type', 'text/xml');
+        await sleep(100);
+        res.write(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                '<url><loc>http://not-exists.com/slow-2-page-1</loc></url>',
+                '<url><loc>http://not-exists.com/slow-2-page-2</loc></url>',
+                '</urlset>',
+            ].join('\n'),
+        );
+        concurrencyLoadTimes['slow-2-end'] = Date.now();
+        res.end();
+    });
+
+    app.get('/sitemap-slow-3.xml', async (req, res) => {
+        concurrencyLoadTimes['slow-3-start'] = Date.now();
+        res.setHeader('content-type', 'text/xml');
+        await sleep(100);
+        res.write(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                '<url><loc>http://not-exists.com/slow-3-page-1</loc></url>',
+                '<url><loc>http://not-exists.com/slow-3-page-2</loc></url>',
+                '</urlset>',
+            ].join('\n'),
+        );
+        concurrencyLoadTimes['slow-3-end'] = Date.now();
+        res.end();
+    });
+
+    app.get('/sitemap-index-slow.xml', async (req, res) => {
+        res.setHeader('content-type', 'text/xml');
+        res.write(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                '<sitemap>',
+                `<loc>${url}/sitemap-slow-1.xml</loc>`,
+                '</sitemap>',
+                '<sitemap>',
+                `<loc>${url}/sitemap-slow-2.xml</loc>`,
+                '</sitemap>',
+                '<sitemap>',
+                `<loc>${url}/sitemap-slow-3.xml</loc>`,
+                '</sitemap>',
+                '</sitemapindex>',
+            ].join('\n'),
+        );
+        res.end();
+    });
+
+    app.get('/concurrency-load-times', (req, res) => {
+        res.json(concurrencyLoadTimes);
+    });
+
+    app.delete('/concurrency-load-times', (req, res) => {
+        Object.keys(concurrencyLoadTimes).forEach((key) => delete concurrencyLoadTimes[key]);
+        res.status(204).end();
+    });
 });
 
 afterAll(async () => {
@@ -539,5 +623,162 @@ describe('SitemapRequestList', () => {
 
         expect(restoredRequest!.url).toEqual(firstLoadedUrl);
         expect(restoredRequest!.userData).toEqual(userDataPayload);
+    });
+
+    describe('concurrency', () => {
+        beforeEach(async () => {
+            // Reset concurrency load times before each test
+            await fetch(`${url}/concurrency-load-times`, { method: 'DELETE' });
+        });
+
+        test('concurrency option loads multiple sitemaps in parallel', async () => {
+            const list = await SitemapRequestList.open({
+                sitemapUrls: [`${url}/sitemap-index-slow.xml`],
+                concurrency: 3,
+            });
+
+            for await (const request of list) {
+                await list.markRequestHandled(request);
+            }
+
+            expect(list.handledCount()).toBe(6);
+
+            // Verify that sitemaps were loaded in parallel by checking timestamps
+            const loadTimes = await fetch(`${url}/concurrency-load-times`).then((r) => r.json());
+
+            // With concurrency=3, all three slow sitemaps should start roughly at the same time
+            // (within a small window, accounting for the index sitemap being parsed first)
+            const startTimes = [loadTimes['slow-1-start'], loadTimes['slow-2-start'], loadTimes['slow-3-start']];
+            const maxStartDiff = Math.max(...startTimes) - Math.min(...startTimes);
+
+            // If loaded in parallel, start times should be within ~50ms of each other
+            // If loaded sequentially, they would be ~100ms apart
+            expect(maxStartDiff).toBeLessThan(80);
+        });
+
+        test('concurrency=1 loads sitemaps sequentially (default behavior)', async () => {
+            const list = await SitemapRequestList.open({
+                sitemapUrls: [`${url}/sitemap-index-slow.xml`],
+                concurrency: 1,
+            });
+
+            for await (const request of list) {
+                await list.markRequestHandled(request);
+            }
+
+            expect(list.handledCount()).toBe(6);
+
+            // Verify sequential loading
+            const loadTimes = await fetch(`${url}/concurrency-load-times`).then((r) => r.json());
+
+            // With concurrency=1, each sitemap should start after the previous one ends
+            // Check that slow-2 started after slow-1 ended (or close to it)
+            if (loadTimes['slow-1-end'] && loadTimes['slow-2-start']) {
+                expect(loadTimes['slow-2-start']).toBeGreaterThanOrEqual(loadTimes['slow-1-end'] - 20);
+            }
+        });
+
+        test('concurrency respects the limit', async () => {
+            const list = await SitemapRequestList.open({
+                sitemapUrls: [`${url}/sitemap-index-slow.xml`],
+                concurrency: 2, // Only 2 at a time, but 3 sub-sitemaps
+            });
+
+            for await (const request of list) {
+                await list.markRequestHandled(request);
+            }
+
+            expect(list.handledCount()).toBe(6);
+
+            const loadTimes = await fetch(`${url}/concurrency-load-times`).then((r) => r.json());
+
+            // With concurrency=2, two sitemaps start in parallel, third waits
+            const startTimes = [loadTimes['slow-1-start'], loadTimes['slow-2-start'], loadTimes['slow-3-start']];
+
+            // Sort to find which two started first
+            startTimes.sort((a, b) => a - b);
+
+            // First two should be close together
+            expect(startTimes[1] - startTimes[0]).toBeLessThan(50);
+
+            // Third should be delayed (started after one of the first two finished)
+            expect(startTimes[2] - startTimes[0]).toBeGreaterThan(80);
+        });
+
+        test('concurrent loading collects all URLs without duplicates', async () => {
+            const list = await SitemapRequestList.open({
+                sitemapUrls: [`${url}/sitemap-index-slow.xml`],
+                concurrency: 3,
+            });
+
+            const urls = new Set<string>();
+
+            for await (const request of list) {
+                urls.add(request.url);
+                await list.markRequestHandled(request);
+            }
+
+            expect(urls.size).toBe(6);
+            expect(urls).toContain('http://not-exists.com/slow-1-page-1');
+            expect(urls).toContain('http://not-exists.com/slow-1-page-2');
+            expect(urls).toContain('http://not-exists.com/slow-2-page-1');
+            expect(urls).toContain('http://not-exists.com/slow-2-page-2');
+            expect(urls).toContain('http://not-exists.com/slow-3-page-1');
+            expect(urls).toContain('http://not-exists.com/slow-3-page-2');
+        });
+
+        test('concurrent loading with abort signal', async () => {
+            const controller = new AbortController();
+
+            const list = await SitemapRequestList.open({
+                sitemapUrls: [`${url}/sitemap-index-slow.xml`],
+                concurrency: 3,
+                signal: controller.signal,
+            });
+
+            // Abort quickly, before all sitemaps finish loading
+            await sleep(50);
+            controller.abort();
+
+            for await (const request of list) {
+                await list.markRequestHandled(request);
+            }
+
+            // Should have stopped early
+            expect(list.isSitemapFullyLoaded()).toBe(false);
+            expect(list.isFinished()).resolves.toBe(true);
+        });
+
+        test('state persistence works with concurrency', async () => {
+            const options = {
+                sitemapUrls: [`${url}/sitemap-index-slow.xml`],
+                persistStateKey: 'concurrency-persist',
+                concurrency: 2,
+            };
+
+            {
+                const list = await SitemapRequestList.open(options);
+
+                // Wait for some URLs to be loaded
+                while (await list.isEmpty()) {
+                    await sleep(20);
+                }
+
+                const request = await list.fetchNextRequest();
+                await list.markRequestHandled(request!);
+
+                await list.persistState();
+            }
+
+            // Restore and continue
+            const newList = await SitemapRequestList.open(options);
+
+            for await (const request of newList) {
+                await newList.markRequestHandled(request);
+            }
+
+            // Total handled should be 6 (minus whatever was handled before persist, plus new list)
+            expect(newList.handledCount()).toBeGreaterThanOrEqual(5);
+        });
     });
 });


### PR DESCRIPTION
Hey there!

Right now, nested sitemap discovery is sequential. 

It can be quite slow for large sitemaps and slow remote servers.

This PR introduces a batching mechanism (the same one as the core) and a new `concurrency` (default) 1 allowing to batch sitemaps in //

I did the code with the help of Cursor / Opus 4.5, and my own inputs.

Do whatever you want with it :) 

I can help to change the design if needed.