### PR TITLE
fix(puppeteer-crawler): migrate cookie handling to browser-context API

### DIFF
--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -278,3 +278,5 @@ This aligns the Puppeteer controller with the Playwright controller, which has a
 - Cookie writes are applied to the whole browser context. When you launch pages with shared contexts, cookies written via `Session.setCookiesFromResponse` or similar will be visible to every other page in that context.
 
 If you rely on Crawlee's default configuration (one browser context per session, which is the `useIncognitoPages` / `newContextPerSession` behavior used by `PuppeteerCrawler`), you should not notice any difference — each session already owns its own context.
+
+**Cookie `url` field** — the old `page.setCookie()` auto-filled a missing `url` on each cookie with the page's current URL. The new `browserContext().setCookie()` does not; Chromium rejects cookies that carry neither `url` nor `domain`. Crawlee's internal `_setCookies` keeps the old behavior by back-filling `page.url()` for any cookie that has neither field set, but if you call `browserContext().setCookie()` directly (outside of Crawlee) you need to provide one of them yourself.

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -266,3 +266,15 @@ The `transformRequestFunction` callback receives a `RequestOptions` object and c
 - A new `RequestOptions` plain object
 - `'unchanged'` to keep the original options as-is
 - A falsy value or `'skip'` to exclude the request from the queue
+
+## Puppeteer cookies are now read and written at the browser-context level
+
+The `PuppeteerController._getCookies` / `_setCookies` methods (used internally by the session pool to sync cookies between a `Session` and a Puppeteer page) now call `page.browserContext().cookies()` / `setCookie()` instead of the deprecated `page.cookies()` / `page.setCookie()`. The page-level API was removed in newer Puppeteer releases.
+
+This aligns the Puppeteer controller with the Playwright controller, which has always worked at the context level.
+
+**What changes in practice**
+- Cookie reads return every cookie stored in the page's browser context, not just cookies matching the page's current URL. If your `Session` relied on the URL-scoped filtering (for example, to avoid pulling cookies that belong to other tabs in the same context), you'll now see the full set.
+- Cookie writes are applied to the whole browser context. When you launch pages with shared contexts, cookies written via `Session.setCookiesFromResponse` or similar will be visible to every other page in that context.
+
+If you rely on Crawlee's default configuration (one browser context per session, which is the `useIncognitoPages` / `newContextPerSession` behavior used by `PuppeteerCrawler`), you should not notice any difference — each session already owns its own context.

--- a/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
@@ -140,10 +140,10 @@ export class PuppeteerController extends BrowserController<
     }
 
     protected async _getCookies(page: PuppeteerTypes.Page): Promise<Cookie[]> {
-        return page.cookies();
+        return page.browserContext().cookies();
     }
 
     protected async _setCookies(page: PuppeteerTypes.Page, cookies: Cookie[]): Promise<void> {
-        return page.setCookie(...cookies);
+        return page.browserContext().setCookie(...(cookies as PuppeteerTypes.CookieData[]));
     }
 }

--- a/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
@@ -144,6 +144,12 @@ export class PuppeteerController extends BrowserController<
     }
 
     protected async _setCookies(page: PuppeteerTypes.Page, cookies: Cookie[]): Promise<void> {
-        return page.browserContext().setCookie(...(cookies as PuppeteerTypes.CookieData[]));
+        // BrowserContext.setCookie requires `url` or `domain`; the page-level API used to back-fill
+        // the page's current URL for us. Replicate that so callers who pass neither don't get rejected.
+        const pageUrl = page.url();
+        const normalized = cookies.map((cookie) =>
+            cookie.url || cookie.domain ? cookie : { ...cookie, url: pageUrl },
+        );
+        return page.browserContext().setCookie(...(normalized as PuppeteerTypes.CookieData[]));
     }
 }


### PR DESCRIPTION
## Summary

Switches \`PuppeteerController._getCookies\` / \`_setCookies\` from the deprecated page-level API (\`page.cookies\` / \`page.setCookie\`) to the browser-context API (\`page.browserContext().cookies\` / \`setCookie\`). This aligns the Puppeteer controller with the Playwright controller, which has always operated at the context level.

## Behavior change

The page-level API returned cookies scoped to the page's current URL; the context API returns every cookie in the browser context. For the default Crawlee setup (one context per session — the \`useIncognitoPages\` / \`newContextPerSession\` pattern used by \`PuppeteerCrawler\`) there is no visible difference. Users that share a browser context across sessions will see cookies bleed between tabs, which matches playwright-side semantics.

Documented in \`docs/upgrading/upgrading_v4.md\`.

## Why split out

Surfaced in review of #3569 — that PR is a tooling migration (eslint/biome → oxlint/oxfmt) and originally carried this change as a drive-by "fix a deprecation warning". Splitting it out keeps the migration PR behavior-neutral and gives this behavior change a proper changelog entry.