### PR TITLE
fix: honor custom respectRobotsTxtFile userAgent in enqueueLinks

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1703,9 +1703,6 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         request: Request<Dictionary>,
         requestQueue: RequestProvider,
     ): Promise<BatchAddRequestsResult> {
-        const robotsTxtUserAgent =
-            typeof this.respectRobotsTxtFile === 'object' ? this.respectRobotsTxtFile?.userAgent : undefined;
-
         const transformRequestFunctionWrapper: RequestTransform = (newRequest) => {
             newRequest.crawlDepth = request.crawlDepth + 1;
 
@@ -1737,7 +1734,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         return enqueueLinks({
             requestQueue,
             robotsTxtFile: await this.getRobotsTxtFileForUrl(request!.url),
-            robotsTxtUserAgent,
+            respectRobotsTxtFile: this.respectRobotsTxtFile,
             onSkippedRequest,
             limit: this.calculateEnqueuedRequestLimit(options.limit),
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1703,6 +1703,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         request: Request<Dictionary>,
         requestQueue: RequestProvider,
     ): Promise<BatchAddRequestsResult> {
+        const robotsTxtUserAgent =
+            typeof this.respectRobotsTxtFile === 'object' ? this.respectRobotsTxtFile?.userAgent : undefined;
+
         const transformRequestFunctionWrapper: RequestTransform = (newRequest) => {
             newRequest.crawlDepth = request.crawlDepth + 1;
 
@@ -1734,6 +1737,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         return enqueueLinks({
             requestQueue,
             robotsTxtFile: await this.getRobotsTxtFileForUrl(request!.url),
+            robotsTxtUserAgent,
             onSkippedRequest,
             limit: this.calculateEnqueuedRequestLimit(options.limit),
 

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -183,6 +183,12 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
     robotsTxtFile?: Pick<RobotsTxtFile, 'isAllowed'>;
 
     /**
+     * User-agent name to use when evaluating {@apilink EnqueueLinksOptions.robotsTxtFile|`robotsTxtFile`} rules.
+     * Defaults to `*` when not provided.
+     */
+    robotsTxtUserAgent?: string;
+
+    /**
      * When a request is skipped for some reason, you can use this callback to act on it.
      * This is currently fired for requests skipped
      * 1. based on robots.txt file,
@@ -296,6 +302,7 @@ export async function enqueueLinks(
             urls: ow.array.ofType(ow.string),
             requestQueue: ow.object.hasKeys('addRequestsBatched'),
             robotsTxtFile: ow.optional.object.hasKeys('isAllowed'),
+            robotsTxtUserAgent: ow.optional.string,
             onSkippedRequest: ow.optional.function,
             forefront: ow.optional.boolean,
             skipNavigation: ow.optional.boolean,
@@ -426,7 +433,7 @@ export async function enqueueLinks(
         const skippedRequests: RequestOptions[] = [];
 
         requestOptions = requestOptions.filter((request) => {
-            if (robotsTxtFile.isAllowed(request.url)) {
+            if (robotsTxtFile.isAllowed(request.url, options.robotsTxtUserAgent ?? '*')) {
                 return true;
             }
 

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -183,10 +183,11 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
     robotsTxtFile?: Pick<RobotsTxtFile, 'isAllowed'>;
 
     /**
-     * User-agent name to use when evaluating {@apilink EnqueueLinksOptions.robotsTxtFile|`robotsTxtFile`} rules.
-     * Defaults to `*` when not provided.
+     * Mirrors {@apilink BasicCrawlerOptions.respectRobotsTxtFile}: pass `false` to disable filtering or
+     * `{ userAgent }` to evaluate rules for a specific user-agent. Defaults to `*` when
+     * {@apilink EnqueueLinksOptions.robotsTxtFile|`robotsTxtFile`} is provided.
      */
-    robotsTxtUserAgent?: string;
+    respectRobotsTxtFile?: boolean | { userAgent?: string };
 
     /**
      * When a request is skipped for some reason, you can use this callback to act on it.
@@ -302,7 +303,7 @@ export async function enqueueLinks(
             urls: ow.array.ofType(ow.string),
             requestQueue: ow.object.hasKeys('addRequestsBatched'),
             robotsTxtFile: ow.optional.object.hasKeys('isAllowed'),
-            robotsTxtUserAgent: ow.optional.string,
+            respectRobotsTxtFile: ow.optional.any(ow.boolean, ow.object.exactShape({ userAgent: ow.optional.string })),
             onSkippedRequest: ow.optional.function,
             forefront: ow.optional.boolean,
             skipNavigation: ow.optional.boolean,
@@ -429,11 +430,13 @@ export async function enqueueLinks(
 
     let requestOptions = createRequestOptions(urls, options);
 
-    if (robotsTxtFile) {
+    if (robotsTxtFile && options.respectRobotsTxtFile !== false) {
+        const robotsUserAgent =
+            typeof options.respectRobotsTxtFile === 'object' ? (options.respectRobotsTxtFile.userAgent ?? '*') : '*';
         const skippedRequests: RequestOptions[] = [];
 
         requestOptions = requestOptions.filter((request) => {
-            if (robotsTxtFile.isAllowed(request.url, options.robotsTxtUserAgent ?? '*')) {
+            if (robotsTxtFile.isAllowed(request.url, robotsUserAgent)) {
                 return true;
             }
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1722,6 +1722,55 @@ describe('BasicCrawler', () => {
             expect(addRequestsBatchedSpy).toHaveBeenCalledOnce();
         });
 
+        test('enqueueLinks should respect custom user-agent robots.txt rules', async () => {
+            const requestQueue = await RequestQueue.open();
+            const visitedUrls: string[] = [];
+
+            const crawler = new (class MockedRobotsTxtCrawler extends BasicCrawler {
+                override async getRobotsTxtFileForUrl(_: string) {
+                    return RobotsTxtFile.from(
+                        'http://example.com/robots.txt',
+                        `User-agent: *
+                         Disallow: /
+                         Allow: /yes
+
+                         User-agent: MyCrawler
+                         Disallow: /no
+                         Allow: /my-crawler
+                        `,
+                    );
+                }
+            })({
+                requestQueue,
+                respectRobotsTxtFile: { userAgent: 'MyCrawler' },
+                requestHandler: async (context) => {
+                    visitedUrls.push(context.request.url);
+
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    await context.enqueueLinks({
+                        urls: [
+                            'http://example.com/yes',
+                            'http://example.com/no',
+                            'http://example.com/no-globally',
+                            'http://example.com/my-crawler/anything',
+                        ],
+                        label: 'child',
+                    });
+                },
+            });
+
+            await crawler.run(['http://example.com/start']);
+
+            expect(visitedUrls).toEqual([
+                'http://example.com/start',
+                'http://example.com/yes',
+                'http://example.com/my-crawler/anything',
+            ]);
+        });
+
         test('enqueueLinks should respect maxRequestsPerCrawl', async () => {
             const requestQueue = await RequestQueue.open();
             const addRequestsBatchedSpy = vitest.spyOn(requestQueue, 'addRequestsBatched');

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1742,6 +1742,7 @@ describe('BasicCrawler', () => {
                 }
             })({
                 requestQueue,
+                maxConcurrency: 1,
                 respectRobotsTxtFile: { userAgent: 'MyCrawler' },
                 requestHandler: async (context) => {
                     visitedUrls.push(context.request.url);

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1772,6 +1772,29 @@ describe('BasicCrawler', () => {
             ]);
         });
 
+        test('enqueueLinks forwards respectRobotsTxtFile.userAgent to the robots.txt check', async () => {
+            const requestQueue = await RequestQueue.open();
+            const isAllowedSpy = vitest.fn(() => true);
+
+            const crawler = new (class MockedRobotsTxtCrawler extends BasicCrawler {
+                override async getRobotsTxtFileForUrl(_: string) {
+                    return { isAllowed: isAllowedSpy } as unknown as RobotsTxtFile;
+                }
+            })({
+                requestQueue,
+                maxConcurrency: 1,
+                respectRobotsTxtFile: { userAgent: 'MyCrawler' },
+                requestHandler: async (context) => {
+                    if (context.request.label) return;
+                    await context.enqueueLinks({ urls: ['http://example.com/child'], label: 'child' });
+                },
+            });
+
+            await crawler.run(['http://example.com/start']);
+
+            expect(isAllowedSpy).toHaveBeenCalledWith('http://example.com/child', 'MyCrawler');
+        });
+
         test('enqueueLinks should respect maxRequestsPerCrawl', async () => {
             const requestQueue = await RequestQueue.open();
             const addRequestsBatchedSpy = vitest.spyOn(requestQueue, 'addRequestsBatched');

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -9,7 +9,7 @@ import {
     launchPuppeteer,
     RequestQueue,
 } from '@crawlee/puppeteer';
-import { RobotsTxtFile, type CheerioRoot } from '@crawlee/utils';
+import { type CheerioRoot, RobotsTxtFile } from '@crawlee/utils';
 import { load } from 'cheerio';
 import type { Browser as PlaywrightBrowser, Page as PlaywrightPage } from 'playwright';
 import type { Browser as PuppeteerBrowser, Page as PuppeteerPage } from 'puppeteer';

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -1,4 +1,5 @@
 import { type AddRequestsBatchedOptions, cheerioCrawlerEnqueueLinks } from '@crawlee/cheerio';
+import { enqueueLinks } from '@crawlee/core';
 import { launchPlaywright } from '@crawlee/playwright';
 import type { RequestQueueOperationOptions, Source } from '@crawlee/puppeteer';
 import {
@@ -8,7 +9,7 @@ import {
     launchPuppeteer,
     RequestQueue,
 } from '@crawlee/puppeteer';
-import { type CheerioRoot } from '@crawlee/utils';
+import { RobotsTxtFile, type CheerioRoot } from '@crawlee/utils';
 import { load } from 'cheerio';
 import type { Browser as PlaywrightBrowser, Page as PlaywrightPage } from 'playwright';
 import type { Browser as PuppeteerBrowser, Page as PuppeteerPage } from 'puppeteer';
@@ -1025,6 +1026,64 @@ describe('enqueueLinks()', () => {
             for (let i = 0; i < 5; i++) {
                 expect(enqueued[i].options!.waitForAllRequestsToBeAdded).toBe(true);
             }
+        });
+    });
+
+    describe('respectRobotsTxtFile option', () => {
+        const robotsTxtFile = RobotsTxtFile.from(
+            'http://example.com/robots.txt',
+            `User-agent: *
+             Disallow: /
+             Allow: /yes
+
+             User-agent: MyCrawler
+             Disallow: /no
+             Allow: /my-crawler
+            `,
+        );
+
+        const urls = [
+            'http://example.com/yes',
+            'http://example.com/no',
+            'http://example.com/no-globally',
+            'http://example.com/my-crawler/anything',
+        ];
+
+        test('defaults to the catch-all user-agent when not provided', async () => {
+            const { enqueued, requestQueue } = createRequestQueueMock();
+
+            await enqueueLinks({ urls, requestQueue, robotsTxtFile });
+
+            expect(enqueued.map((r) => r.url)).toEqual(['http://example.com/yes']);
+        });
+
+        test('applies rules for the configured user-agent', async () => {
+            const { enqueued, requestQueue } = createRequestQueueMock();
+
+            await enqueueLinks({
+                urls,
+                requestQueue,
+                robotsTxtFile,
+                respectRobotsTxtFile: { userAgent: 'MyCrawler' },
+            });
+
+            expect(enqueued.map((r) => r.url)).toEqual([
+                'http://example.com/yes',
+                'http://example.com/my-crawler/anything',
+            ]);
+        });
+
+        test('skips filtering when set to false even if robotsTxtFile is provided', async () => {
+            const { enqueued, requestQueue } = createRequestQueueMock();
+
+            await enqueueLinks({
+                urls,
+                requestQueue,
+                robotsTxtFile,
+                respectRobotsTxtFile: false,
+            });
+
+            expect(enqueued.map((r) => r.url)).toEqual(urls);
         });
     });
 });


### PR DESCRIPTION
Closes #3576

- core issue: #3226 added custom `respectRobotsTxtFile.userAgent` support for crawler-level robots checks, but `enqueueLinks()` still evaluated child URLs with the default `*` agent.
- this made `addRequests()` and `enqueueLinks()` disagree on the same robots.txt rules when a custom user-agent was configured.

- **Fix**:
  - thread an optional `robotsTxtUserAgent` through `enqueueLinks()` options
  - pass the configured user-agent from `BasicCrawler.enqueueLinksWithCrawlDepth()`
  - keep the default `*` behavior unchanged when no custom user-agent is configured
  - add a regression test covering `enqueueLinks()` with custom user-agent robots rules

This keeps the change narrow and focused on restoring consistent robots.txt behavior across Crawlee's enqueue paths.
