### PR TITLE
docs: fix spelling for System Information V2 experiment

### DIFF
--- a/docs/experiments/systemInfoV2.mdx
+++ b/docs/experiments/systemInfoV2.mdx
@@ -1,6 +1,6 @@
 ---
-id: experiments-system-infomation-v2
-title: System Infomation V2
+id: experiments-system-information-v2
+title: System Information V2
 description: Improved autoscaling through cgroup aware metric collection.
 ---
 
@@ -61,7 +61,7 @@ when a container is detected.
 :::note
 
 This `isContainerized()` function is very similar to the existing `isDocker()` function however for now they both work side by side.
-If this experiment is successful, eventualy `isDocker()` may eventually be depreciated in favour of `isContainerized()`.
+If this experiment is successful, `isDocker()` may eventually be deprecated in favour of `isContainerized()`.
 
 :::
 

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -559,7 +559,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * If the dataset is empty, reduce will return undefined.
      *
      * @param iteratee
-     * @param memo Unset parameter, neccesary to be able to pass options
+     * @param memo Unset parameter, necessary to be able to pass options
      * @param [options] An object containing extra options for `reduce()`
      */
     async reduce(

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -166,6 +166,30 @@ module.exports = {
                         from: '/js/docs/guides/apify-platform',
                         to: '/js/docs/deployment/apify-platform',
                     },
+                    {
+                        from: '/js/docs/experiments/experiments-system-infomation-v2',
+                        to: '/js/docs/experiments/experiments-system-information-v2',
+                    },
+                    {
+                        from: '/js/docs/next/experiments/experiments-system-infomation-v2',
+                        to: '/js/docs/next/experiments/experiments-system-information-v2',
+                    },
+                    {
+                        from: '/js/docs/3.13/experiments/experiments-system-infomation-v2',
+                        to: '/js/docs/3.13/experiments/experiments-system-information-v2',
+                    },
+                    {
+                        from: '/js/docs/3.14/experiments/experiments-system-infomation-v2',
+                        to: '/js/docs/3.14/experiments/experiments-system-information-v2',
+                    },
+                    {
+                        from: '/js/docs/3.15/experiments/experiments-system-infomation-v2',
+                        to: '/js/docs/3.15/experiments/experiments-system-information-v2',
+                    },
+                    {
+                        from: '/js/docs/3.16/experiments/experiments-system-infomation-v2',
+                        to: '/js/docs/experiments/experiments-system-information-v2',
+                    },
                 ],
                 // createRedirects(existingPath) {
                 //     if (!existingPath.endsWith('/')) {

--- a/website/src/pages/js.js
+++ b/website/src/pages/js.js
@@ -278,7 +278,7 @@ function DeployToCloudSection() {
                         <div>2</div>
                     </div>
                     <div className={styles.deployToCloudStepText}>
-                        Add <pre>Actor.init()</pre> to the begining and{' '}
+                        Add <pre>Actor.init()</pre> to the beginning and{' '}
                         <pre>Actor.exit()</pre> to the end of your code.
                     </div>
                 </div>

--- a/website/versioned_docs/version-3.13/experiments/systemInfoV2.mdx
+++ b/website/versioned_docs/version-3.13/experiments/systemInfoV2.mdx
@@ -1,6 +1,6 @@
 ---
-id: experiments-system-infomation-v2
-title: System Infomation V2
+id: experiments-system-information-v2
+title: System Information V2
 description: Improved autoscaling through cgroup aware metric collection.
 ---
 
@@ -61,7 +61,7 @@ when a container is detected.
 :::note
 
 This `isContainerized()` function is very similar to the existing `isDocker()` function however for now they both work side by side.
-If this experiment is successful, eventualy `isDocker()` may eventually be depreciated in favour of `isContainerized()`.
+If this experiment is successful, `isDocker()` may eventually be deprecated in favour of `isContainerized()`.
 
 :::
 

--- a/website/versioned_docs/version-3.14/experiments/systemInfoV2.mdx
+++ b/website/versioned_docs/version-3.14/experiments/systemInfoV2.mdx
@@ -1,6 +1,6 @@
 ---
-id: experiments-system-infomation-v2
-title: System Infomation V2
+id: experiments-system-information-v2
+title: System Information V2
 description: Improved autoscaling through cgroup aware metric collection.
 ---
 
@@ -61,7 +61,7 @@ when a container is detected.
 :::note
 
 This `isContainerized()` function is very similar to the existing `isDocker()` function however for now they both work side by side.
-If this experiment is successful, eventualy `isDocker()` may eventually be depreciated in favour of `isContainerized()`.
+If this experiment is successful, `isDocker()` may eventually be deprecated in favour of `isContainerized()`.
 
 :::
 

--- a/website/versioned_docs/version-3.15/experiments/systemInfoV2.mdx
+++ b/website/versioned_docs/version-3.15/experiments/systemInfoV2.mdx
@@ -1,6 +1,6 @@
 ---
-id: experiments-system-infomation-v2
-title: System Infomation V2
+id: experiments-system-information-v2
+title: System Information V2
 description: Improved autoscaling through cgroup aware metric collection.
 ---
 
@@ -61,7 +61,7 @@ when a container is detected.
 :::note
 
 This `isContainerized()` function is very similar to the existing `isDocker()` function however for now they both work side by side.
-If this experiment is successful, eventualy `isDocker()` may eventually be depreciated in favour of `isContainerized()`.
+If this experiment is successful, `isDocker()` may eventually be deprecated in favour of `isContainerized()`.
 
 :::
 

--- a/website/versioned_docs/version-3.16/experiments/systemInfoV2.mdx
+++ b/website/versioned_docs/version-3.16/experiments/systemInfoV2.mdx
@@ -1,6 +1,6 @@
 ---
-id: experiments-system-infomation-v2
-title: System Infomation V2
+id: experiments-system-information-v2
+title: System Information V2
 description: Improved autoscaling through cgroup aware metric collection.
 ---
 
@@ -61,7 +61,7 @@ when a container is detected.
 :::note
 
 This `isContainerized()` function is very similar to the existing `isDocker()` function however for now they both work side by side.
-If this experiment is successful, eventualy `isDocker()` may eventually be depreciated in favour of `isContainerized()`.
+If this experiment is successful, `isDocker()` may eventually be deprecated in favour of `isContainerized()`.
 
 :::
 


### PR DESCRIPTION
Rename the experiment doc id from `experiments-system-infomation-v2` to `experiments-system-information-v2` and update the page title.  
Register client redirects from the old paths for the default docs, next, and versioned 3.13–3.16 routes so existing links keep working.  

Tighten the `isDocker()` deprecation sentence, correct JSDoc spelling in `Dataset.pushData`, and fix a typo on the JS landing page.

```
Infomation -> Information
eventualy -> eventually
depreciated -> deprecated
neccesary -> necessary
```