### PR TITLE
fix: prevent iframe expansion failure on pages with Trusted Types CSP

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -623,6 +623,12 @@ export async function parseWithCheerio(
         const frames = await page.$$('iframe');
         const cheerioIframes = $('iframe').toArray();
 
+        if (frames.length !== cheerioIframes.length) {
+            log.warning(
+                `parseWithCheerio: iframe count mismatch between live DOM (${frames.length}) and page snapshot (${cheerioIframes.length}). Some iframes may not be expanded.`,
+            );
+        }
+
         await Promise.all(
             frames.map(async (frame, index) => {
                 try {

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -613,15 +613,22 @@ export async function parseWithCheerio(
 ): Promise<CheerioRoot> {
     ow(page, ow.object.validate(validators.browserPage));
 
+    const html = ignoreShadowRoots
+        ? null
+        : ((await page.evaluate(`(${expandShadowRoots.toString()})(document)`)) as string);
+    const pageContent = html || (await page.content());
+    const $ = cheerio.load(pageContent);
+
     if (page.frames().length > 1 && !ignoreIframes) {
         const frames = await page.$$('iframe');
+        const cheerioIframes = $('iframe').toArray();
 
         await Promise.all(
-            frames.map(async (frame) => {
+            frames.map(async (frame, index) => {
                 try {
                     const iframe = await frame.contentFrame();
 
-                    if (iframe) {
+                    if (iframe && cheerioIframes[index]) {
                         const getIframeHTML = async (): Promise<string> => {
                             try {
                                 return iframe.locator('body').first().innerHTML();
@@ -631,14 +638,9 @@ export async function parseWithCheerio(
                         };
 
                         const contents = await getIframeHTML();
-
-                        await frame.evaluate((f, c) => {
-                            const replacementNode = document.createElement('div');
-                            replacementNode.innerHTML = c;
-                            replacementNode.className = 'crawlee-iframe-replacement';
-
-                            f.replaceWith(replacementNode);
-                        }, contents);
+                        $(cheerioIframes[index]).replaceWith(
+                            `<div class="crawlee-iframe-replacement">${contents}</div>`,
+                        );
                     }
                 } catch (error) {
                     log.warning(`Failed to extract iframe content: ${error}`);
@@ -647,12 +649,7 @@ export async function parseWithCheerio(
         );
     }
 
-    const html = ignoreShadowRoots
-        ? null
-        : ((await page.evaluate(`(${expandShadowRoots.toString()})(document)`)) as string);
-    const pageContent = html || (await page.content());
-
-    return cheerio.load(pageContent);
+    return $;
 }
 
 let idcacPlaywright: null | { getInjectableScript: () => string } = null;

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -185,6 +185,25 @@ describe('playwrightUtils', () => {
         }
     });
 
+    test('parseWithCheerio() iframe expansion works with Trusted Types CSP', async () => {
+        const browser = await launchPlaywright(launchContext);
+
+        try {
+            const page = await browser.newPage();
+            await page.goto(new URL('/special/outside-iframe-csp', serverAddress).toString());
+
+            const $ = await playwrightUtils.parseWithCheerio(page);
+
+            const headings = $('h1')
+                .map((_, el) => $(el).text())
+                .get();
+
+            expect(headings).toEqual(['Outside iframe', 'In iframe']);
+        } finally {
+            await browser.close();
+        }
+    });
+
     describe('blockRequests()', () => {
         let browser: Browser = null as any;
         beforeAll(async () => {

--- a/test/shared/_helper.ts
+++ b/test/shared/_helper.ts
@@ -320,6 +320,11 @@ export async function runExampleComServer(): Promise<[Server, number]> {
             res.type('html').send(responseSamples.outsideIframe);
         });
 
+        special.get('/outside-iframe-csp', (_req, res) => {
+            res.setHeader('Content-Security-Policy', "require-trusted-types-for 'script'");
+            res.type('html').send(responseSamples.outsideIframe);
+        });
+
         special.get('/inside-iframe', (_req, res) => {
             res.type('html').send(responseSamples.insideIframe);
         });


### PR DESCRIPTION
Pages enforcing a Trusted Types Content Security Policy (e.g. Google Sheets) block any browser-side HTML string assignment — including innerHTML and DOMParser.parseFromString. The iframe expansion in parseWithCheerio used frame.evaluate() to inject iframe content into the browser DOM, which was silently blocked by CSP, causing iframe content to be dropped without any visible error.                                                                                                                                                                                                                                                                                              

The fix moves HTML assembly out of the browser entirely. page.content() is called first, loaded into Cheerio on the Node.js side, and iframe content (fetched via Playwright's Node.js API, which is unaffected by CSP) is substituted directly in the Cheerio tree.

Closes #3588 