### PR TITLE
feat: expose Download objects on PlaywrightCrawlingContext

### DIFF
--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -11,7 +11,7 @@ import { BrowserCrawler, Configuration, Router } from '@crawlee/browser';
 import type { BrowserPoolOptions, CommonPage, PlaywrightController, PlaywrightPlugin } from '@crawlee/browser-pool';
 import type { Dictionary } from '@crawlee/types';
 import ow from 'ow';
-import type { LaunchOptions, Page, Response } from 'playwright';
+import type { Download, LaunchOptions, Page, Response } from 'playwright';
 
 import type { PlaywrightLaunchContext } from './playwright-launcher';
 import { PlaywrightLauncher } from './playwright-launcher';
@@ -244,7 +244,9 @@ export class PlaywrightCrawler extends BrowserCrawler<
         createNewSession?: boolean,
     ): void {
         super._enhanceCrawlingContextWithPageInfo(crawlingContext, page, createNewSession);
-        (page as Page).on('download', (download) => crawlingContext.downloads.push(download));
+        const downloads: Download[] = [];
+        (page as Page).on('download', (download) => downloads.push(download));
+        crawlingContext.listDownloads = () => downloads;
     }
 
     protected override async _runRequestHandler(context: PlaywrightCrawlingContext) {

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -246,7 +246,7 @@ export class PlaywrightCrawler extends BrowserCrawler<
         super._enhanceCrawlingContextWithPageInfo(crawlingContext, page, createNewSession);
         const downloads: Download[] = [];
         (page as Page).on('download', (download) => downloads.push(download));
-        crawlingContext.listDownloads = () => downloads;
+        crawlingContext.listDownloads = async () => downloads;
     }
 
     protected override async _runRequestHandler(context: PlaywrightCrawlingContext) {

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -8,7 +8,7 @@ import type {
     RouterRoutes,
 } from '@crawlee/browser';
 import { BrowserCrawler, Configuration, Router } from '@crawlee/browser';
-import type { BrowserPoolOptions, PlaywrightController, PlaywrightPlugin } from '@crawlee/browser-pool';
+import type { BrowserPoolOptions, CommonPage, PlaywrightController, PlaywrightPlugin } from '@crawlee/browser-pool';
 import type { Dictionary } from '@crawlee/types';
 import ow from 'ow';
 import type { LaunchOptions, Page, Response } from 'playwright';
@@ -236,6 +236,15 @@ export class PlaywrightCrawler extends BrowserCrawler<
         browserPoolOptions.browserPlugins = [playwrightLauncher.createBrowserPlugin()];
 
         super({ ...browserCrawlerOptions, launchContext, browserPoolOptions }, config);
+    }
+
+    protected override _enhanceCrawlingContextWithPageInfo(
+        crawlingContext: PlaywrightCrawlingContext,
+        page: CommonPage,
+        createNewSession?: boolean,
+    ): void {
+        super._enhanceCrawlingContextWithPageInfo(crawlingContext, page, createNewSession);
+        (page as Page).on('download', (download) => crawlingContext.downloads.push(download));
     }
 
     protected override async _runRequestHandler(context: PlaywrightCrawlingContext) {

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -1074,7 +1074,7 @@ export interface PlaywrightContextUtils {
      * **Example usage**
      * ```ts
      * requestHandler: async ({ listDownloads }) => {
-     *     for (const download of listDownloads()) {
+     *     for (const download of await listDownloads()) {
      *         try {
      *             const stream = await download.createReadStream();
      *             // stream to storage...
@@ -1085,7 +1085,7 @@ export interface PlaywrightContextUtils {
      * },
      * ```
      */
-    listDownloads(): Download[];
+    listDownloads(): Promise<Download[]>;
 }
 
 export function registerUtilsToContext(

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -34,7 +34,7 @@ import type { BatchAddRequestsResult } from '@crawlee/types';
 import { type CheerioRoot, type Dictionary, expandShadowRoots, sleep } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import ow from 'ow';
-import type { Page, Response, Route } from 'playwright';
+import type { Download, Page, Response, Route } from 'playwright';
 
 import { LruCache } from '@apify/datastructures';
 import log_ from '@apify/log';
@@ -1062,12 +1062,40 @@ export interface PlaywrightContextUtils {
      * @param [options]
      */
     handleCloudflareChallenge(options?: HandleCloudflareChallengeOptions): Promise<void>;
+
+    /**
+     * A list of {@link https://playwright.dev/docs/api/class-download | Download} objects
+     * triggered during the current page navigation.
+     *
+     * Playwright intercepts downloads before they complete, so the objects are available
+     * as soon as the browser starts the download — including inside `errorHandler` when
+     * `page.goto` throws `"Download is starting"`.
+     *
+     * > **Note:** Playwright saves download data to a temporary file on disk. For very large
+     * > files this may be a concern; prefer re-enqueueing the URL to a streaming downloader
+     * > when file size is unpredictable.
+     *
+     * **Example usage**
+     * ```ts
+     * errorHandler: async ({ downloads, request }, error) => {
+     *     if (error.message.includes('Download is starting')) {
+     *         for (const download of downloads) {
+     *             const stream = await download.createReadStream();
+     *             // stream to storage...
+     *         }
+     *     }
+     * },
+     * ```
+     */
+    downloads: Download[];
 }
 
 export function registerUtilsToContext(
     context: PlaywrightCrawlingContext,
     crawlerOptions: PlaywrightCrawlerOptions,
 ): void {
+    context.downloads = [];
+
     context.injectFile = async (filePath: string, options?: InjectFileOptions) =>
         injectFile(context.page, filePath, options);
     context.injectJQuery = async () => {

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -1067,22 +1067,17 @@ export interface PlaywrightContextUtils {
      * A list of {@link https://playwright.dev/docs/api/class-download | Download} objects
      * triggered during the current page navigation.
      *
-     * Playwright intercepts downloads before they complete, so the objects are available
-     * as soon as the browser starts the download — including inside `errorHandler` when
-     * `page.goto` throws `"Download is starting"`.
-     *
-     * > **Note:** Playwright saves download data to a temporary file on disk. For very large
-     * > files this may be a concern; prefer re-enqueueing the URL to a streaming downloader
-     * > when file size is unpredictable.
+     * Useful for accessing files that the page downloads automatically during navigation.
+     * For most use cases, prefer re-enqueueing the URL to {@apilink FileDownload}.
+     * Use this only when direct access to the Playwright `Download` object is required.
      *
      * **Example usage**
      * ```ts
-     * errorHandler: async ({ downloads, request }, error) => {
-     *     if (error.message.includes('Download is starting')) {
-     *         for (const download of downloads) {
-     *             const stream = await download.createReadStream();
-     *             // stream to storage...
-     *         }
+     * requestHandler: async ({ downloads }) => {
+     *     for (const download of downloads) {
+     *         const stream = await download.createReadStream();
+     *         if (!stream) continue; // download failed or was cancelled
+     *         // stream to storage...
      *     }
      * },
      * ```

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -1064,33 +1064,34 @@ export interface PlaywrightContextUtils {
     handleCloudflareChallenge(options?: HandleCloudflareChallengeOptions): Promise<void>;
 
     /**
-     * A list of {@link https://playwright.dev/docs/api/class-download | Download} objects
-     * triggered during the current page navigation.
+     * Returns the list of {@link https://playwright.dev/docs/api/class-download | Download} objects
+     * collected during the current page navigation and request handler.
      *
-     * Useful for accessing files that the page downloads automatically during navigation.
+     * Useful for accessing files that the page downloads automatically.
      * For most use cases, prefer re-enqueueing the URL to {@apilink FileDownload}.
      * Use this only when direct access to the Playwright `Download` object is required.
      *
      * **Example usage**
      * ```ts
-     * requestHandler: async ({ downloads }) => {
-     *     for (const download of downloads) {
-     *         const stream = await download.createReadStream();
-     *         if (!stream) continue; // download failed or was cancelled
-     *         // stream to storage...
+     * requestHandler: async ({ listDownloads }) => {
+     *     for (const download of listDownloads()) {
+     *         try {
+     *             const stream = await download.createReadStream();
+     *             // stream to storage...
+     *         } catch {
+     *             // download failed or was cancelled
+     *         }
      *     }
      * },
      * ```
      */
-    downloads: Download[];
+    listDownloads(): Download[];
 }
 
 export function registerUtilsToContext(
     context: PlaywrightCrawlingContext,
     crawlerOptions: PlaywrightCrawlerOptions,
 ): void {
-    context.downloads = [];
-
     context.injectFile = async (filePath: string, options?: InjectFileOptions) =>
         injectFile(context.page, filePath, options);
     context.injectJQuery = async () => {

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -226,13 +226,13 @@ describe('PlaywrightCrawler', () => {
             maxRequestRetries: 0,
             maxConcurrency: 1,
             requestHandler: async ({ page, listDownloads }) => {
-                countBefore = listDownloads().length;
+                countBefore = (await listDownloads()).length;
 
                 const downloadPromise = page.waitForEvent('download');
                 await page.click('a#download-link');
                 await downloadPromise;
 
-                const downloads = listDownloads();
+                const downloads = await listDownloads();
                 countAfter = downloads.length;
                 suggestedFilename = downloads[0]?.suggestedFilename();
             },

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -41,6 +41,16 @@ describe('PlaywrightCrawler', () => {
             res.send(`<html><head><title>Example Domain</title></head></html>`);
             res.status(200);
         });
+        app.get('/page-with-download', (_req, res) => {
+            res.status(200).send(
+                `<html><body><a id="download-link" href="/download-file" download="hello.txt">download</a></body></html>`,
+            );
+        });
+        app.get('/download-file', (_req, res) => {
+            res.setHeader('Content-Type', 'text/plain');
+            res.setHeader('Content-Disposition', 'attachment; filename="hello.txt"');
+            res.send('hello');
+        });
     });
 
     beforeAll(async () => {
@@ -163,48 +173,76 @@ describe('PlaywrightCrawler', () => {
         expect(Object.keys(options.browserPoolOptions).length).toBe(0);
     });
 
-    test.each([
-        { useIncognitoPages: true },
-        { useIncognitoPages: false },
-    ])('should apply launchOptions with useIncognitoPages: $useIncognitoPages', async ({ useIncognitoPages }) => {
-        // Some launch options apply to the browser, while some apply to the context.
-        // Here we use some context options to verify that those are actually applied.
-        const launchOptions = {
-            locale: 'cz-CZ',
-            reducedMotion: 'reduce' as const,
-            timezoneId: 'Pacific/Tahiti',
-        };
+    test.each([{ useIncognitoPages: true }, { useIncognitoPages: false }])(
+        'should apply launchOptions with useIncognitoPages: $useIncognitoPages',
+        async ({ useIncognitoPages }) => {
+            // Some launch options apply to the browser, while some apply to the context.
+            // Here we use some context options to verify that those are actually applied.
+            const launchOptions = {
+                locale: 'cz-CZ',
+                reducedMotion: 'reduce' as const,
+                timezoneId: 'Pacific/Tahiti',
+            };
 
-        let [timezone, locale, reducedMotion] = ['', '', ''];
+            let [timezone, locale, reducedMotion] = ['', '', ''];
+
+            const playwrightCrawler = new PlaywrightCrawler({
+                maxConcurrency: 1,
+                launchContext: {
+                    useIncognitoPages,
+                    launchOptions,
+                },
+                browserPoolOptions: {
+                    // don't overwrite locale with fingerprint's locale
+                    useFingerprints: false,
+                },
+                requestHandler: async ({ page }) => {
+                    [timezone, locale, reducedMotion] = await Promise.all([
+                        page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
+                        page.evaluate(() => navigator.language),
+                        page.evaluate(() => {
+                            return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+                                ? 'reduce'
+                                : 'no-preference';
+                        }),
+                    ]);
+                },
+            });
+
+            await playwrightCrawler.run([`http://${HOSTNAME}:${port}/`]);
+
+            expect(timezone).toBe(launchOptions.timezoneId);
+            expect(locale).toBe(launchOptions.locale);
+            expect(reducedMotion).toBe(launchOptions.reducedMotion);
+        },
+    );
+
+    test('exposes triggered downloads via listDownloads()', async () => {
+        let countBefore = -1;
+        let countAfter = -1;
+        let suggestedFilename: string | undefined;
 
         const playwrightCrawler = new PlaywrightCrawler({
+            maxRequestRetries: 0,
             maxConcurrency: 1,
-            launchContext: {
-                useIncognitoPages,
-                launchOptions,
-            },
-            browserPoolOptions: {
-                // don't overwrite locale with fingerprint's locale
-                useFingerprints: false,
-            },
-            requestHandler: async ({ page }) => {
-                [timezone, locale, reducedMotion] = await Promise.all([
-                    page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
-                    page.evaluate(() => navigator.language),
-                    page.evaluate(() => {
-                        return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-                            ? 'reduce'
-                            : 'no-preference';
-                    }),
-                ]);
+            requestHandler: async ({ page, listDownloads }) => {
+                countBefore = listDownloads().length;
+
+                const downloadPromise = page.waitForEvent('download');
+                await page.click('a#download-link');
+                await downloadPromise;
+
+                const downloads = listDownloads();
+                countAfter = downloads.length;
+                suggestedFilename = downloads[0]?.suggestedFilename();
             },
         });
 
-        await playwrightCrawler.run([`http://${HOSTNAME}:${port}/`]);
+        await playwrightCrawler.run([`http://${HOSTNAME}:${port}/page-with-download`]);
 
-        expect(timezone).toBe(launchOptions.timezoneId);
-        expect(locale).toBe(launchOptions.locale);
-        expect(reducedMotion).toBe(launchOptions.reducedMotion);
+        expect(countBefore).toBe(0);
+        expect(countAfter).toBe(1);
+        expect(suggestedFilename).toBe('hello.txt');
     });
 
     test('should have correct types in crawling context', async () => {

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -173,49 +173,49 @@ describe('PlaywrightCrawler', () => {
         expect(Object.keys(options.browserPoolOptions).length).toBe(0);
     });
 
-    test.each([{ useIncognitoPages: true }, { useIncognitoPages: false }])(
-        'should apply launchOptions with useIncognitoPages: $useIncognitoPages',
-        async ({ useIncognitoPages }) => {
-            // Some launch options apply to the browser, while some apply to the context.
-            // Here we use some context options to verify that those are actually applied.
-            const launchOptions = {
-                locale: 'cz-CZ',
-                reducedMotion: 'reduce' as const,
-                timezoneId: 'Pacific/Tahiti',
-            };
+    test.each([
+        { useIncognitoPages: true },
+        { useIncognitoPages: false },
+    ])('should apply launchOptions with useIncognitoPages: $useIncognitoPages', async ({ useIncognitoPages }) => {
+        // Some launch options apply to the browser, while some apply to the context.
+        // Here we use some context options to verify that those are actually applied.
+        const launchOptions = {
+            locale: 'cz-CZ',
+            reducedMotion: 'reduce' as const,
+            timezoneId: 'Pacific/Tahiti',
+        };
 
-            let [timezone, locale, reducedMotion] = ['', '', ''];
+        let [timezone, locale, reducedMotion] = ['', '', ''];
 
-            const playwrightCrawler = new PlaywrightCrawler({
-                maxConcurrency: 1,
-                launchContext: {
-                    useIncognitoPages,
-                    launchOptions,
-                },
-                browserPoolOptions: {
-                    // don't overwrite locale with fingerprint's locale
-                    useFingerprints: false,
-                },
-                requestHandler: async ({ page }) => {
-                    [timezone, locale, reducedMotion] = await Promise.all([
-                        page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
-                        page.evaluate(() => navigator.language),
-                        page.evaluate(() => {
-                            return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-                                ? 'reduce'
-                                : 'no-preference';
-                        }),
-                    ]);
-                },
-            });
+        const playwrightCrawler = new PlaywrightCrawler({
+            maxConcurrency: 1,
+            launchContext: {
+                useIncognitoPages,
+                launchOptions,
+            },
+            browserPoolOptions: {
+                // don't overwrite locale with fingerprint's locale
+                useFingerprints: false,
+            },
+            requestHandler: async ({ page }) => {
+                [timezone, locale, reducedMotion] = await Promise.all([
+                    page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
+                    page.evaluate(() => navigator.language),
+                    page.evaluate(() => {
+                        return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+                            ? 'reduce'
+                            : 'no-preference';
+                    }),
+                ]);
+            },
+        });
 
-            await playwrightCrawler.run([`http://${HOSTNAME}:${port}/`]);
+        await playwrightCrawler.run([`http://${HOSTNAME}:${port}/`]);
 
-            expect(timezone).toBe(launchOptions.timezoneId);
-            expect(locale).toBe(launchOptions.locale);
-            expect(reducedMotion).toBe(launchOptions.reducedMotion);
-        },
-    );
+        expect(timezone).toBe(launchOptions.timezoneId);
+        expect(locale).toBe(launchOptions.locale);
+        expect(reducedMotion).toBe(launchOptions.reducedMotion);
+    });
 
     test('exposes triggered downloads via listDownloads()', async () => {
         let countBefore = -1;


### PR DESCRIPTION
 When page.goto throws "Download is starting", Playwright has already captured the file — but the Download object was inaccessible to user-land code. The only workaround was re-downloading via HTTP, which breaks on sites requiring a
 browser session (e.g. ECAS-gated resources on Eur-Lex).                                                                  
                                                            
  This PR adds a downloads: Download[] array to PlaywrightCrawlingContext, populated via page.on('download', ...)
  registered in _enhanceCrawlingContextWithPageInfo — before navigation, so downloads triggered by page.goto are always
  captured.
 
 Closes #3583 