### PR TITLE
chore(e2e): bump `apify-node-curl-impersonate` in tests

### DIFF
--- a/test/e2e/cheerio-curl-impersonate-ts/actor/package.json
+++ b/test/e2e/cheerio-curl-impersonate-ts/actor/package.json
@@ -3,17 +3,17 @@
     "version": "0.0.1",
     "description": "Cheerio Crawler Test - curl-impersonate HTTP client",
     "dependencies": {
-        "apify": "next",
         "@apify/storage-local": "^2.1.3",
         "@crawlee/basic": "file:./packages/basic-crawler",
         "@crawlee/browser-pool": "file:./packages/browser-pool",
-        "@crawlee/http": "file:./packages/http-crawler",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
         "@crawlee/core": "file:./packages/core",
+        "@crawlee/http": "file:./packages/http-crawler",
         "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
-        "apify-node-curl-impersonate": "1.0.15"
+        "apify": "next",
+        "apify-node-curl-impersonate": "^1.0.29"
     },
     "overrides": {
         "apify": {
@@ -24,8 +24,8 @@
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",
-        "typescript": "^5.0.0",
-        "@types/node": "^24.0.0"
+        "@types/node": "^24.0.0",
+        "typescript": "^5.0.0"
     },
     "scripts": {
         "start": "tsc && node main.js",


### PR DESCRIPTION
Unpins and bumps the `apify-node-curl-impersonate` version in the related e2e test. Other changes are just sorting / formatting.

Fixes E2E test issues as seen, e.g., [here](https://console.apify.com/view/runs/Lt8jLfogVl0hmZqe8) (caused by old browser fingerprints with mismatching headers).