### PR TITLE
chore: pass --no-error-on-unmatched-pattern to oxlint in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     },
     "lint-staged": {
         "{packages,test,docs}/**/*.{js,ts,mjs,mts,cjs,cts}": [
-            "oxlint --fix",
+            "oxlint --fix --no-error-on-unmatched-pattern",
             "oxfmt --write --no-error-on-unmatched-pattern"
         ]
     },


### PR DESCRIPTION
## Summary
When a commit only touches files under `test/e2e/**` (skipped by oxlint's `ignorePatterns`), `oxlint --fix` exits with an error because no files match, breaking the lint-staged hook. Mirrors the flag already used for `oxfmt` so the hook succeeds in this case.

Closes #3610

🤖 Generated with [Claude Code](https://claude.com/claude-code)